### PR TITLE
Config/container renderers

### DIFF
--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/ConfigUtil.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/ConfigUtil.java
@@ -3,6 +3,8 @@ package com.github.mkram17.bazaarutils.config.util;
 import com.github.mkram17.bazaarutils.BazaarUtils;
 import com.github.mkram17.bazaarutils.config.BUConfig;
 import com.github.mkram17.bazaarutils.config.patcher.ConfigPatches;
+import com.github.mkram17.bazaarutils.config.util.client.ItemRendererProvider;
+import com.github.mkram17.bazaarutils.config.util.client.SlotRendererProvider;
 import com.github.mkram17.bazaarutils.utils.Util;
 import com.google.gson.JsonObject;
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigScreen;
@@ -62,6 +64,9 @@ public class ConfigUtil {
                             "— expected VERSION = " + (PATCHES.size() + 1)
             );
         }
+        
+        ItemRendererProvider.register();
+        SlotRendererProvider.register();
 
         configurator.register(BUConfig.class, event ->
                 PATCHES.forEach((version, patch) ->

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ItemElement.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ItemElement.java
@@ -1,0 +1,123 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ItemTag;
+import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
+import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.ResourcefulConfigElement;
+import com.teamresourceful.resourcefulconfig.api.types.elements.ResourcefulConfigEntryElement;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import com.teamresourceful.resourcefulconfig.api.types.options.EntryType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+public final class ItemElement implements ResourcefulConfigEntryElement {
+    private final ResourcefulConfigEntryElement delegate;
+
+    private final String tag;
+
+    private ItemElement(ResourcefulConfigEntryElement delegate, String tag) {
+        this.delegate = delegate;
+        this.tag = tag;
+    }
+
+    public static ItemElement wrap(ResourcefulConfigElement element) {
+        if (!(element instanceof ResourcefulConfigEntryElement entry)) return null;
+        if (!(entry.entry() instanceof ResourcefulConfigValueEntry value)) return null;
+        if (!(value.type() == EntryType.STRING)) return null;
+
+        Field field = entryField(entry);
+
+        if (field == null) return null;
+
+        String tag = field.isAnnotationPresent(ItemTag.class) ? field.getAnnotation(ItemTag.class).value() : "";
+
+        return new ItemElement(entry, tag);
+    }
+
+    private static Field entryField(ResourcefulConfigEntryElement delegate) {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    public String tag() {
+        return tag;
+    }
+
+    public ResourcefulConfigValueEntry valueEntry() {
+        return (ResourcefulConfigValueEntry) delegate.entry();
+    }
+
+    public Text title() {
+        Field field = entryField();
+
+        if (field != null) {
+            ConfigEntry options = field.getAnnotation(ConfigEntry.class);
+
+            if (options != null && !options.translation().isEmpty()) {
+                return Text.translatable(options.translation());
+            }
+        }
+
+        return Text.literal(delegate.id());
+    }
+
+    public Text description() {
+        Field field = entryField();
+
+        if (field != null) {
+            Comment comment = field.getAnnotation(Comment.class);
+
+            if (comment != null) {
+                return !comment.translation().isEmpty()
+                        ? Text.translatable(comment.translation())
+                        : Text.literal(comment.value());
+            }
+        }
+
+        return Text.empty();
+    }
+
+    @Override public ResourcefulConfigEntry entry() {
+        return delegate.entry();
+    }
+
+    @Override public String id() {
+        return delegate.id();
+    }
+
+    @Override public Identifier renderer() {
+        return delegate.renderer();
+    }
+
+    @Override public boolean isHidden() {
+        return delegate.isHidden();
+    }
+
+    @Override public boolean search(Predicate<String> predicate) {
+        return delegate.search(predicate);
+    }
+
+    private Field entryField() {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
@@ -1,0 +1,41 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public final class ResourcefulConfigItems {
+    private static Supplier<List<Item>> source = () -> Registries.ITEM.stream().toList();
+
+    private static Predicate<Item> globalFilter = item -> true;
+
+    private ResourcefulConfigItems() {}
+
+    public static void setSource(Supplier<List<Item>> source) {
+        ResourcefulConfigItems.source = source;
+    }
+
+    public static void addGlobalFilter(Predicate<Item> filter) {
+        Predicate<Item> existing = ResourcefulConfigItems.globalFilter;
+        ResourcefulConfigItems.globalFilter = item -> existing.test(item) && filter.test(item);
+    }
+
+    public static List<Item> getItems(String tag) {
+        List<Item> base = source.get().stream().filter(globalFilter).toList();
+        if (tag == null || tag.isEmpty()) return base;
+        Identifier tagId = Identifier.tryParse(tag);
+        if (tagId == null) return base;
+        TagKey<Item> tagKey = TagKey.of(RegistryKeys.ITEM, tagId);
+        return base.stream().filter(item -> item.getRegistryEntry().isIn(tagKey)).toList();
+    }
+
+    public static List<Item> getItems() {
+        return getItems("");
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
@@ -5,26 +5,48 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public final class ResourcefulConfigItems {
+    private static final Map<String, Item> RESOLVED_CACHE = new HashMap<>();
+
+    public static @Nullable Item resolve(String rawId) {
+        if (rawId == null || rawId.isEmpty()) return null;
+
+        return RESOLVED_CACHE.computeIfAbsent(rawId, id -> {
+            Identifier identifier = Identifier.tryParse(id);
+
+            if (identifier == null) return null;
+
+            return source.get().stream()
+                    .filter(item -> Registries.ITEM.getId(item).equals(identifier))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+
     private static Supplier<List<Item>> source = () -> Registries.ITEM.stream().toList();
-
-    private static Predicate<Item> globalFilter = item -> true;
-
-    private ResourcefulConfigItems() {}
 
     public static void setSource(Supplier<List<Item>> source) {
         ResourcefulConfigItems.source = source;
     }
 
+    private static Predicate<Item> globalFilter = item -> true;
+
     public static void addGlobalFilter(Predicate<Item> filter) {
         Predicate<Item> existing = ResourcefulConfigItems.globalFilter;
         ResourcefulConfigItems.globalFilter = item -> existing.test(item) && filter.test(item);
     }
+
+
+    private ResourcefulConfigItems() {}
 
     public static List<Item> getItems(String tag) {
         List<Item> base = source.get().stream().filter(globalFilter).toList();

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotElement.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotElement.java
@@ -1,0 +1,127 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
+import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
+import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.ResourcefulConfigElement;
+import com.teamresourceful.resourcefulconfig.api.types.elements.ResourcefulConfigEntryElement;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import com.teamresourceful.resourcefulconfig.api.types.options.EntryType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+public final class SlotElement implements ResourcefulConfigEntryElement {
+    private final ResourcefulConfigEntryElement delegate;
+
+    private final int rows;
+    private final int cols;
+
+    private final SlotProvider provider;
+
+    private SlotElement(ResourcefulConfigEntryElement delegate, int rows, int cols, SlotProvider provider) {
+        this.delegate = delegate;
+        this.rows = rows;
+        this.cols = cols;
+        this.provider = provider;
+    }
+
+    public static SlotElement wrap(ResourcefulConfigElement element) {
+        if (!(element instanceof ResourcefulConfigEntryElement entry)) return null;
+        if (!(entry.entry() instanceof ResourcefulConfigValueEntry value)) return null;
+        if (value.type() != EntryType.INTEGER) return null;
+
+        Field field = entryField(entry);
+
+        if (field == null || !field.isAnnotationPresent(ContainerSlot.class)) return null;
+
+        ContainerSlot options = field.getAnnotation(ContainerSlot.class);
+        SlotProvider provider = SlotProviders.get(options.provider());
+
+        return new SlotElement(entry, options.rows(), options.cols(), provider);
+    }
+
+    public int rows() {
+        return rows;
+    }
+
+    public int cols() {
+        return cols;
+    }
+
+    public int totalSlots() {
+        return rows * cols;
+    }
+
+    public SlotProvider provider() {
+        return provider;
+    }
+
+    public ResourcefulConfigValueEntry valueEntry() {
+        return (ResourcefulConfigValueEntry) delegate.entry();
+    }
+
+    public Text title() {
+        Field field = entryField(delegate);
+
+        if (field != null) {
+            ConfigEntry options = field.getAnnotation(ConfigEntry.class);
+
+            if (options != null && !options.translation().isEmpty()) return Text.translatable(options.translation());
+        }
+
+        return Text.literal(delegate.id());
+    }
+
+    public Text description() {
+        Field field = entryField(delegate);
+
+        if (field != null) {
+            Comment comment = field.getAnnotation(Comment.class);
+
+            if (comment != null) {
+                return !comment.translation().isEmpty()
+                        ? Text.translatable(comment.translation())
+                        : Text.literal(comment.value());
+            }
+        }
+
+        return Text.empty();
+    }
+
+    @Override public ResourcefulConfigEntry entry() {
+        return delegate.entry();
+    }
+
+    @Override public String id() {
+        return delegate.id();
+    }
+
+    @Override public Identifier renderer() {
+        return delegate.renderer();
+    }
+
+    @Override public boolean isHidden() {
+        return delegate.isHidden();
+    }
+
+    @Override public boolean search(Predicate<String> predicate) {
+        return delegate.search(predicate);
+    }
+
+    private static Field entryField(ResourcefulConfigEntryElement delegate) {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
@@ -1,0 +1,8 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import net.minecraft.item.ItemStack;
+
+@FunctionalInterface
+public interface SlotProvider {
+    ItemStack getStack(int slotIndex);
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,0 +1,46 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SlotProviders {
+    private static final Map<String, SlotProvider> REGISTRY = new HashMap<>();
+
+    private SlotProviders() {}
+
+    public static void register(String key, SlotProvider provider) {
+        REGISTRY.put(key, provider);
+    }
+
+    public static SlotProvider get(String key) {
+        if (key == null || key.isEmpty()) return slot -> ItemStack.EMPTY;
+
+        return REGISTRY.getOrDefault(key, slot -> ItemStack.EMPTY);
+    }
+
+    public static ItemStack named(Item item, Text name) {
+        return named(item, 1, name);
+    }
+
+    public static ItemStack named(Item item, int count, Text name) {
+        ItemStack stack = new ItemStack(item, count);
+        stack.set(DataComponentTypes.CUSTOM_NAME, name);
+
+        return stack;
+    }
+
+    public static ItemStack hiddenTooltip(Item item, int count) {
+        ItemStack stack = new ItemStack(item, count);
+
+        stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, new ReferenceLinkedOpenHashSet<>()));
+
+        return stack;
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,6 +1,8 @@
 package com.github.mkram17.bazaarutils.config.util.api;
 
-import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import com.github.mkram17.bazaarutils.BazaarUtils;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
+import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.item.Item;
@@ -25,22 +27,53 @@ public final class SlotProviders {
         return REGISTRY.getOrDefault(key, slot -> ItemStack.EMPTY);
     }
 
-    public static ItemStack named(Item item, Text name) {
-        return named(item, 1, name);
+    public static SlotStack stack(Item item) {
+        return new SlotStack(item, 1);
     }
 
-    public static ItemStack named(Item item, int count, Text name) {
-        ItemStack stack = new ItemStack(item, count);
-        stack.set(DataComponentTypes.CUSTOM_NAME, name);
-
-        return stack;
+    public static SlotStack stack(Item item, int count) {
+        return new SlotStack(item, count);
     }
 
-    public static ItemStack hiddenTooltip(Item item, int count) {
-        ItemStack stack = new ItemStack(item, count);
+    public static final class SlotStack {
 
-        stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, new ReferenceLinkedOpenHashSet<>()));
+        private final ItemStack stack;
 
-        return stack;
+        private SlotStack(Item item, int count) {
+            this.stack = new ItemStack(item, count);
+        }
+
+        public SlotStack named(Text name) {
+            stack.set(DataComponentTypes.CUSTOM_NAME, name);
+            return this;
+        }
+
+        public SlotStack named(String name) {
+            return named(Text.literal(name));
+        }
+
+        public SlotStack locked() {
+            stack.set(CustomDataComponents.SLOT_SELECTOR_LOCKED, true);
+            return this;
+        }
+
+        public SlotStack hideTooltip() {
+            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, ReferenceSortedSets.emptySet()));
+            return this;
+        }
+
+//      we hide attributes by default
+//        public SlotStack hideAttributes() {
+//            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
+//            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
+//            return this;
+//        }
+
+        public ItemStack build() {
+            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
+            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
+
+            return stack;
+        }
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ContainerSlot.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ContainerSlot.java
@@ -1,0 +1,15 @@
+package com.github.mkram17.bazaarutils.config.util.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ContainerSlot {
+    int rows();
+    int cols();
+
+    String provider() default "";
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ItemTag.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ItemTag.java
@@ -1,0 +1,12 @@
+package com.github.mkram17.bazaarutils.config.util.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ItemTag {
+    String value();
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
@@ -37,9 +37,10 @@ public record ItemRenderer(ItemElement element) implements ResourcefulConfigElem
         ItemStringOptionWidget stringWidget = new ItemStringOptionWidget(
                 entry::getString,
                 s -> {
-                    Identifier id = Identifier.tryParse(s);
-                    if (id == null) return false;
-                    if (items.stream().noneMatch(item -> Registries.ITEM.getId(item).equals(id))) return false;
+                    Item resolved = ResourcefulConfigItems.resolve(s);
+
+                    if (resolved == null || !items.contains(resolved)) return false;
+
                     entry.setString(s);
                     return true;
                 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
@@ -1,0 +1,57 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.ItemElement;
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.ItemOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.ItemStringOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.ResetOptionWidget;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigElementRenderer;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public record ItemRenderer(ItemElement element) implements ResourcefulConfigElementRenderer {
+    @Override
+    public Text title() {
+        return element.title();
+    }
+
+    @Override
+    public Text description() {
+        return element.description();
+    }
+
+    @Override
+    public List<ClickableWidget> widgets() {
+        ResourcefulConfigValueEntry entry = element.valueEntry();
+
+        List<Item> items = ResourcefulConfigItems.getItems(element.tag());
+
+        ItemOptionWidget itemWidget = new ItemOptionWidget(items, entry::getString, entry::setString);
+
+        ItemStringOptionWidget stringWidget = new ItemStringOptionWidget(
+                entry::getString,
+                s -> {
+                    Identifier id = Identifier.tryParse(s);
+                    if (id == null) return false;
+                    if (items.stream().noneMatch(item -> Registries.ITEM.getId(item).equals(id))) return false;
+                    entry.setString(s);
+                    return true;
+                }
+        );
+
+        return List.of(
+                itemWidget,
+                stringWidget,
+                ResetOptionWidget.of(() -> {
+                    entry.reset();
+                    stringWidget.reset();
+                })
+        );
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRendererProvider.java
@@ -1,0 +1,19 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.ItemElement;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
+import net.minecraft.util.Identifier;
+
+public final class ItemRendererProvider {
+    private ItemRendererProvider() {}
+
+    public static void register() {
+        ResourcefulConfigUI.registerElementRenderer(
+                Identifier.of("bazaarutils", "item"),
+                element -> {
+                    ItemElement ie = ItemElement.wrap(element);
+                    return ie != null ? new ItemRenderer(ie) : null;
+                }
+        );
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRenderer.java
@@ -1,0 +1,44 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.ResetOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.SlotNumberOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.SlotOptionWidget;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigElementRenderer;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.text.Text;
+
+import java.util.List;
+
+public record SlotRenderer(SlotElement element) implements ResourcefulConfigElementRenderer {
+    @Override
+    public Text title() {
+        return element.title();
+    }
+
+    @Override
+    public Text description() {
+        return element.description();
+    }
+
+    @Override
+    public List<ClickableWidget> widgets() {
+        ResourcefulConfigValueEntry entry = element.valueEntry();
+
+        SlotOptionWidget slotWidget = new SlotOptionWidget(
+                element,
+                entry::getInt,
+                entry::setInt
+        );
+
+        SlotNumberOptionWidget numberWidget = new SlotNumberOptionWidget(element);
+
+        ClickableWidget resetWidget = ResetOptionWidget.of(() -> {
+            entry.reset();
+            numberWidget.reset();
+        });
+
+        return List.of(slotWidget, numberWidget, resetWidget);
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
@@ -1,0 +1,23 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
+import net.minecraft.util.Identifier;
+
+public final class SlotRendererProvider {
+    private SlotRendererProvider() {}
+
+    public static void register() {
+        ResourcefulConfigUI.registerElementRenderer(
+                Identifier.of("bazaarutils", "slot"),
+                element -> {
+                    SlotElement se = SlotElement.wrap(element);
+                    return se != null ? new SlotRenderer(se) : null;
+                }
+        );
+
+        registerElementProviders();
+    }
+
+    private static void registerElementProviders() {}
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/AbstractSelectorOverlay.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/AbstractSelectorOverlay.java
@@ -1,0 +1,39 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.screens.base.OverlayScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractSelectorOverlay extends OverlayScreen {
+    protected int ox, oy, ow, oh;
+
+    protected AbstractSelectorOverlay() {
+        super(MinecraftClient.getInstance().currentScreen);
+    }
+
+    protected boolean isOverOverlay(double mouseX, double mouseY) {
+        return mouseX >= ox && mouseX <= ox + ow && mouseY >= oy && mouseY <= oy + oh;
+    }
+
+    @Override
+    public void renderBackground(@NotNull DrawContext context, int mouseX, int mouseY, float delta) {
+        super.renderBackground(context, mouseX, mouseY, delta);
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.ACCENT, ox, oy, ow, oh);
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.BUTTON, ox + 1, oy + 1, ow - 2, oh - 2);
+    }
+
+    @Override
+    public boolean mouseClicked(Click click, boolean doubled) {
+        if (click.button() != 0 || isOverOverlay(click.x(), click.y())) {
+            return super.mouseClicked(click, doubled);
+        }
+
+        close();
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/ResetOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/ResetOptionWidget.java
@@ -1,0 +1,19 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.UIConstants;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.components.base.SpriteButton;
+import net.minecraft.client.gui.widget.ClickableWidget;
+
+public final class ResetOptionWidget {
+    private ResetOptionWidget() {}
+
+    public static ClickableWidget of(Runnable onPress) {
+        return SpriteButton.builder(12, 12)
+                .padding(2)
+                .sprite(ModSprites.RESET)
+                .tooltip(UIConstants.RESET)
+                .onPress(onPress)
+                .build();
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/SelectorOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/SelectorOptionWidget.java
@@ -1,0 +1,17 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.components.base.SpriteButton;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public abstract class SelectorOptionWidget extends SpriteButton implements ResetableWidget {
+    protected static final Text SELECT = Text.translatable("bazaarutils.rconfig.ui.constant.select");
+
+    protected SelectorOptionWidget(Identifier sprite, Text tooltip) {
+        super(12, 12, 2, sprite, () -> {}, tooltip);
+    }
+
+    @Override
+    public void reset() {}
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
 
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
@@ -41,22 +42,11 @@ public class ItemOptionWidget extends SelectorOptionWidget {
         this.setter = setter;
     }
 
-    private @Nullable Item resolveItem() {
-        Identifier id = Identifier.tryParse(getter.get());
-
-        if (id == null) return null;
-
-        return items.stream()
-                .filter(item -> Registries.ITEM.getId(item).equals(id))
-                .findFirst()
-                .orElse(null);
-    }
-
     @Override
     protected void drawIcon(DrawContext context, int mouseX, int mouseY, float delta) {
         super.drawIcon(context, mouseX, mouseY, delta);
 
-        Item item = resolveItem();
+        Item item = ResourcefulConfigItems.resolve(getter.get());
 
         if (item != null) {
             context.drawItem(new ItemStack(item), getX(), getY());

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
@@ -1,0 +1,235 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ItemCell;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.components.options.text.TextBox;
+import com.teamresourceful.resourcefulconfig.client.utils.ListenableState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.input.AbstractInput;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ItemOptionWidget extends SelectorOptionWidget {
+    protected static final Text SEARCH = Text.translatable("bazaarutils.rconfig.ui.constant.search");
+
+    private final List<Item> items;
+    private final Supplier<String> getter;
+    private final Consumer<String> setter;
+
+    public ItemOptionWidget(List<Item> items, Supplier<String> getter, Consumer<String> setter) {
+        super(ModSprites.BUTTON, SELECT);
+        this.items = items;
+        this.getter = getter;
+        this.setter = setter;
+    }
+
+    private @Nullable Item resolveItem() {
+        Identifier id = Identifier.tryParse(getter.get());
+
+        if (id == null) return null;
+
+        return items.stream()
+                .filter(item -> Registries.ITEM.getId(item).equals(id))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    protected void drawIcon(DrawContext context, int mouseX, int mouseY, float delta) {
+        super.drawIcon(context, mouseX, mouseY, delta);
+
+        Item item = resolveItem();
+
+        if (item != null) {
+            context.drawItem(new ItemStack(item), getX(), getY());
+        }
+    }
+
+    @Override
+    public void onPress(@NotNull AbstractInput modifiers) {
+        MinecraftClient.getInstance().setScreen(new ItemSelector(this));
+    }
+
+    public static class ItemSelector extends AbstractSelectorOverlay {
+        private final ItemOptionWidget source;
+
+        private static final int PADDING = 4;
+        private static final int SPACING = 2;
+
+        private static final int GRID_COLS = 8;
+        private static final int MAX_ROWS = 5;
+
+        private static final int SEARCH_HEIGHT = 14;
+        private static final int OVERLAY_WIDTH = GRID_COLS * ContainerCell.CELL_SIZE + PADDING * 2;
+
+        private final Consumer<String> setter;
+
+        private final List<Item> allItems;
+        private List<Item> filteredItems;
+
+        private int scrollOffset = 0;
+
+        private final List<ClickableWidget> cellWidgets = new ArrayList<>();
+
+        private TextBox searchBox;
+
+        public ItemSelector(ItemOptionWidget source) {
+            this.source = source;
+            this.setter = source.setter;
+            this.allItems = source.items;
+            this.filteredItems = new ArrayList<>(allItems);
+        }
+
+        private int totalRows() {
+            return (int) Math.ceil(filteredItems.size() / (double) GRID_COLS);
+        }
+
+        private int maxScroll() {
+            return Math.max(0, totalRows() - MAX_ROWS);
+        }
+
+        private int visibleRows() {
+            return Math.min(MAX_ROWS, totalRows());
+        }
+
+        private int overlayHeight() {
+            return PADDING * 2 + SEARCH_HEIGHT + SPACING + MAX_ROWS * ContainerCell.CELL_SIZE;
+        }
+
+        private void rebuildCells() {
+            cellWidgets.forEach(this::remove);
+            cellWidgets.clear();
+
+            scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScroll());
+            oh = overlayHeight();
+
+            int startX = ox + PADDING;
+            int startY = oy + PADDING + SEARCH_HEIGHT + SPACING;
+            int startIndex = scrollOffset * GRID_COLS;
+
+            for (int i = 0; i < MAX_ROWS * GRID_COLS; i++) {
+                int itemIndex = startIndex + i;
+                if (itemIndex >= filteredItems.size()) break;
+
+                Item item = filteredItems.get(itemIndex);
+                int col = i % GRID_COLS;
+                int row = i / GRID_COLS;
+
+                ItemCell cell = new ItemCell(
+                        startX + col * ContainerCell.CELL_SIZE,
+                        startY + row * ContainerCell.CELL_SIZE,
+                        item,
+                        selected -> {
+                            this.setter.accept(Registries.ITEM.getId(selected).toString());
+                            close();
+                        }
+                );
+                cellWidgets.add(cell);
+                addDrawableChild(cell);
+            }
+        }
+
+        private void applySearch(String query) {
+            String q = query.toLowerCase().trim();
+            scrollOffset = 0;
+
+            filteredItems = allItems.stream().filter(item -> {
+                if (q.isEmpty()) return true;
+
+                String name = item.getName(new ItemStack(item)).getString().toLowerCase();
+                String key = Registries.ITEM.getId(item).toString().toLowerCase();
+
+                return name.contains(q) || key.contains(q);
+            }).toList();
+        }
+
+        @Override
+        protected void init() {
+            ow = OVERLAY_WIDTH;
+            oh = overlayHeight();
+
+            oy = (source.getY() + source.getHeight() + SPACING + oh <= this.height)
+                    ? source.getY() + source.getHeight() + SPACING
+                    : source.getY() - oh - SPACING;
+
+            int centerX = source.getX() + source.getWidth() / 2;
+            ox = MathHelper.clamp(centerX - ow / 2, 0, this.width - ow);
+
+            ListenableState<String> searchState = ListenableState.of("");
+            searchState.registerListener(q -> {
+                applySearch(q);
+                rebuildCells();
+            });
+
+            this.searchBox = new TextBox(ow - PADDING * 2, SEARCH_HEIGHT, searchState) {
+                @Override
+                public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+                    context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.BUTTON, getX(), getY(), getWidth(), getHeight());
+                    super.renderWidget(context, mouseX, mouseY, delta);
+                    this.applyCursor(context);
+                }
+            };
+            this.searchBox.setPosition(ox + PADDING, oy + PADDING);
+            this.searchBox.setPlaceholder(SEARCH.getString(), 0xFF808080);
+            addDrawableChild(this.searchBox);
+
+            rebuildCells();
+        }
+
+        @Override
+        public void renderBackground(@NotNull DrawContext context, int mouseX, int mouseY, float delta) {
+            super.renderBackground(context, mouseX, mouseY, delta);
+
+            if (maxScroll() > 0) {
+                int trackTop = oy + PADDING + SEARCH_HEIGHT + SPACING;
+                int trackHeight = visibleRows() * ContainerCell.CELL_SIZE;
+                int thumbHeight = Math.max(6, trackHeight * MAX_ROWS / totalRows());
+                int thumbTop = trackTop + (trackHeight - thumbHeight) * scrollOffset / Math.max(1, maxScroll());
+                context.fill(ox + ow - 3, trackTop, ox + ow - 1, trackTop + trackHeight, 0x44FFFFFF);
+                context.fill(ox + ow - 3, thumbTop, ox + ow - 1, thumbTop + thumbHeight, 0xAAFFFFFF);
+            }
+        }
+
+        @Override
+        public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+            if (!isOverOverlay(mouseX, mouseY)) return false;
+
+            int newOffset = MathHelper.clamp(scrollOffset - (int) Math.signum(scrollY), 0, maxScroll());
+
+            if (newOffset != scrollOffset) {
+                scrollOffset = newOffset;
+                rebuildCells();
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean charTyped(CharInput input) {
+            if (searchBox != null && !searchBox.isFocused()) {
+                setInitialFocus(searchBox);
+                return searchBox.charTyped(input);
+            }
+
+            return super.charTyped(input);
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
@@ -22,14 +22,7 @@ public class ItemStringOptionWidget extends StringOptionWidget implements Reseta
     @Override
     public void updateIfFocused() {
         if (!isFocused()) {
-            Identifier id = Identifier.tryParse(getter.get());
-
-            Item resolved = id != null
-                    ? ResourcefulConfigItems.getItems().stream()
-                    .filter(item -> Registries.ITEM.getId(item).equals(id))
-                    .findFirst()
-                    .orElse(null)
-                    : null;
+            Item resolved = ResourcefulConfigItems.resolve(getter.get());
 
             setValue(resolved != null ? resolved.getName(new ItemStack(resolved)).getString() : getter.get());
             setCursorPosition(0);

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
@@ -1,0 +1,58 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.StringOptionWidget;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ItemStringOptionWidget extends StringOptionWidget implements ResetableWidget {
+    private final Supplier<String> getter;
+
+    public ItemStringOptionWidget(Supplier<String> getter, Function<String, Boolean> setter) {
+        super(getter, setter, false);
+        this.getter = getter;
+    }
+
+    @Override
+    public void updateIfFocused() {
+        if (!isFocused()) {
+            Identifier id = Identifier.tryParse(getter.get());
+
+            Item resolved = id != null
+                    ? ResourcefulConfigItems.getItems().stream()
+                    .filter(item -> Registries.ITEM.getId(item).equals(id))
+                    .findFirst()
+                    .orElse(null)
+                    : null;
+
+            setValue(resolved != null ? resolved.getName(new ItemStack(resolved)).getString() : getter.get());
+            setCursorPosition(0);
+            setHighlightPos(0);
+            setTextColor(0xFFE0E0E0);
+        }
+    }
+
+    @Override
+    public void setFocused(boolean focused) {
+        boolean wasFocused = isFocused();
+
+        super.setFocused(focused);
+
+        if (focused && !wasFocused) {
+            setValue(getter.get());
+            setCursorPosition(getValue().length());
+            setHighlightPos(getValue().length());
+        }
+    }
+
+    @Override
+    public void reset() {
+        setValue(getter.get());
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
@@ -1,0 +1,35 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.NumberOptionWidget;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+
+public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implements ResetableWidget {
+    private final int maxSlot;
+
+    public SlotNumberOptionWidget(SlotElement element) {
+        super(
+                element.valueEntry()::getInt,
+                value -> {
+                    element.valueEntry().setInt(value);
+                    return true;
+                },
+                s -> {
+                    int value = Integer.parseInt(s);
+                    int max   = element.totalSlots() - 1;
+                    if (value < 0 || value > max) throw new NumberFormatException();
+                    return value;
+                },
+                NumberOptionWidget.INTEGER_FILTER
+        );
+        this.maxSlot = element.totalSlots() - 1;
+    }
+
+    private static final boolean canExpand = false;
+
+    @Override
+    public void updateIfFocused() {
+        // if (!canExpand) return;
+        // rather than to do an unless check, we just no-op, as it should never expand.
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
@@ -1,8 +1,10 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
 
 import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.teamresourceful.resourcefulconfig.client.components.options.types.NumberOptionWidget;
 import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import net.minecraft.item.ItemStack;
 
 public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implements ResetableWidget {
     private final int maxSlot;
@@ -18,6 +20,13 @@ public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implemen
                     int value = Integer.parseInt(s);
                     int max   = element.totalSlots() - 1;
                     if (value < 0 || value > max) throw new NumberFormatException();
+                    ItemStack stack = element.provider().getStack(value);
+                    // Known undeseriable/bug behavior:
+                    // to throw NumberFormatException() will cause the input box to fallback to the last typed-in value,
+                    // not the last saved/valid value. This is a implementation detail of NumberOptionWidget,
+                    // and although we may override and fix it with a custom setChangedListener(...) call,
+                    // it'd be better off if upstream fixes this behavior. 
+                    if (!stack.isEmpty() && stack.contains(CustomDataComponents.SLOT_SELECTOR_LOCKED)) throw new NumberFormatException();
                     return value;
                 },
                 NumberOptionWidget.INTEGER_FILTER

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
@@ -1,0 +1,103 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
+import com.teamresourceful.resourcefulconfig.client.UIConstants;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class SlotOptionWidget extends SelectorOptionWidget {
+    private static final int SIZE = 12;
+
+    private final SlotElement element;
+    private final Supplier<Integer> getter;
+    private final Consumer<Integer> setter;
+
+    public SlotOptionWidget(SlotElement element, Supplier<Integer> getter, Consumer<Integer> setter) {
+        super(ModSprites.EDIT, UIConstants.EDIT);
+        this.element = element;
+        this.getter = getter;
+        this.setter = setter;
+    }
+
+    @Override
+    public void onPress(@NotNull net.minecraft.client.input.AbstractInput modifiers) {
+        MinecraftClient.getInstance().setScreen(new SlotSelector(this, element, getter.get(), setter));
+    }
+
+    public static class SlotSelector extends AbstractSelectorOverlay {
+        private final SlotOptionWidget source;
+
+        private static final int PADDING = 4;
+        private static final int SPACING = 2;
+
+        private final SlotElement element;
+
+        private final Consumer<Integer> setter;
+
+        private int selectedSlot;
+
+        private final List<ClickableWidget> cellWidgets = new ArrayList<>();
+
+        public SlotSelector(SlotOptionWidget source, SlotElement element, int currentSlot, Consumer<Integer> setter) {
+            this.source = source;
+            this.element = element;
+            this.setter = setter;
+            this.selectedSlot = currentSlot;
+        }
+
+        private void rebuildCells() {
+            cellWidgets.forEach(this::remove);
+            cellWidgets.clear();
+
+            int startX = ox + PADDING;
+            int startY = oy + PADDING;
+
+            for (int slot = 0; slot < element.totalSlots(); slot++) {
+                final int s = slot;
+                int col = slot % element.cols();
+                int row = slot / element.cols();
+                ItemStack stack = element.provider().getStack(slot);
+
+                ContainerCell cell = new ContainerCell(
+                        startX + col * ContainerCell.CELL_SIZE,
+                        startY + row * ContainerCell.CELL_SIZE,
+                        stack,
+                        slot == selectedSlot,
+                        () -> {
+                            setter.accept(s);
+                            close();
+                        }
+                );
+                cellWidgets.add(cell);
+                addDrawableChild(cell);
+            }
+        }
+
+        @Override
+        protected void init() {
+            ow = PADDING * 2 + element.cols() * ContainerCell.CELL_SIZE;
+            oh = PADDING * 2 + element.rows() * ContainerCell.CELL_SIZE;
+
+            oy = (source.getY() + source.getHeight() + SPACING + oh <= this.height)
+                    ? source.getY() + source.getHeight() + SPACING
+                    : source.getY() - oh - SPACING;
+
+            int centerX = source.getX() + source.getWidth() / 2;
+            ox = MathHelper.clamp(centerX - ow / 2, 0, this.width - ow);
+
+            rebuildCells();
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
 
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.teamresourceful.resourcefulconfig.client.components.base.BaseWidget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.RenderPipelines;
@@ -28,6 +29,7 @@ public class ContainerCell extends BaseWidget {
         setPosition(x, y);
         this.stack    = stack;
         this.selected = selected;
+        this.active   = !(!stack.isEmpty() && stack.contains(CustomDataComponents.SLOT_SELECTOR_LOCKED));
         this.onSelect = onSelect;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
@@ -1,0 +1,63 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
+
+import com.teamresourceful.resourcefulconfig.client.components.base.BaseWidget;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class ContainerCell extends BaseWidget {
+    public static final int CELL_SIZE = 18;
+    private static final Identifier SLOT_SPRITE = Identifier.ofVanilla("container/slot");
+
+    private final ItemStack stack;
+
+    private final boolean selected;
+
+    private final Runnable onSelect;
+
+    public ContainerCell(int x, int y, ItemStack stack, boolean selected, Runnable onSelect) {
+        super(CELL_SIZE, CELL_SIZE);
+        setPosition(x, y);
+        this.stack    = stack;
+        this.selected = selected;
+        this.onSelect = onSelect;
+    }
+
+    @Override
+    protected void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SLOT_SPRITE, getX(), getY(), CELL_SIZE, CELL_SIZE);
+
+        if (selected) {
+            context.fill(getX() + 1, getY() + 1, getX() + CELL_SIZE - 1, getY() + CELL_SIZE - 1, 0x8800AA00);
+        } else if (isHovered()) {
+            context.fill(getX() + 1, getY() + 1, getX() + CELL_SIZE - 1, getY() + CELL_SIZE - 1, 0x80FFFFFF);
+        }
+
+        if (!stack.isEmpty()) {
+            context.drawItem(stack, getX() + 1, getY() + 1);
+
+            if (isHovered() && !stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT).hideTooltip()) {
+                context.drawTooltip(
+                        MinecraftClient.getInstance().textRenderer,
+                        stack.getTooltip(Item.TooltipContext.DEFAULT, null, TooltipType.BASIC),
+                        mouseX, mouseY
+                );
+            }
+        }
+
+        this.applyCursor(context);
+    }
+
+    @Override
+    public void onClick(@NotNull Click event, boolean doubled) {
+        onSelect.run();
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ItemCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ItemCell.java
@@ -1,0 +1,12 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import java.util.function.Consumer;
+
+public class ItemCell extends ContainerCell {
+    public ItemCell(int x, int y, Item item, Consumer<Item> onSelect) {
+        super(x, y, new ItemStack(item), false, () -> onSelect.accept(item));
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/components/CustomDataComponents.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/components/CustomDataComponents.java
@@ -12,10 +12,12 @@ import net.minecraft.util.Identifier;
 public final class CustomDataComponents {
     public static ComponentType<String> CUSTOM_SIZE;
     public static ComponentType<Boolean> SHOW_PRICE_CHART;
+    public static ComponentType<Boolean> SLOT_SELECTOR_LOCKED;
 
     public CustomDataComponents() {
         CUSTOM_SIZE = register("custom_size", ComponentType.<String>builder().codec(Codec.STRING).build());
         SHOW_PRICE_CHART = register("has_price_chart", ComponentType.<Boolean>builder().codec(Codec.BOOL).build());
+        SLOT_SELECTOR_LOCKED = register("slot_selector_locked", ComponentType.<Boolean>builder().codec(Codec.BOOL).build());
     }
 
     private static <T> ComponentType<T> register(String id, ComponentType<T> type) {

--- a/src/main/resources/assets/bazaarutils/lang/en_us.json5
+++ b/src/main/resources/assets/bazaarutils/lang/en_us.json5
@@ -68,6 +68,13 @@
   "mod.bazaarutils": "Bazaar Utils",
   "key.category.minecraft.bazaarutils": "Bazaar Utils",
 
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Search...",
+      "select": "Select"
+    }
+  },
+
   "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
     "not_upgraded.label": "Not Upgraded",
     "first_tier.label": "Bazaar Flipper I",


### PR DESCRIPTION
should be merged after #72 

Asked on ResourcefulConfigs' Discord whether they'd like me to PR a few elements to alter how primitives are rendered via @ConfigOption, and they decided that these cases should be kept as renderers on a per-project basis.

## Featured Renderers

- `Item`—a string-backed element, that is to be validated and limited to the identifier of an item found within the elements' registry. The element presents two widgets, a string box for users to directly edit the value, and a button to open a selector which can be filtered by tags. [`View Gallery`](https://imgur.com/a/DGcazjG)
- `SlotNumber`—a integer-backed element, that is to be validated and limited to the index of an slot found within the provided registered/specified container. The element presents two widgets, a input box for users to directly edit the value, and a button to open a selector which shows a Minecraft-like inventory that can be populated via providers. [`View Gallery`](https://imgur.com/a/iqaG3Kr)

They'd both be registered as per of https://github.com/mkram17/Bazaar-Utils/pull/73/commits/1a578751f3788816ef97854513046e4602fed861

## Container Renderer

Consumed as: 

```java
    @ConfigEntry(...)
    @Comment(...)
    @ContainerSlot(rows = 4, cols = 9)
    // @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:buy_order_amount") with a container provider/the container that is rendered populated
    @ConfigOption.Renderer("bazaarutils:slot")
    public int slotNumber;
```

The overlay that pops once clicking the edit button calls the declared `SlotProvider` for each cell/slot it is to build, in that of to allow to represent the container that is relevant to this entry/field:
```java
        SlotProviders.register("bazaar:buy_order_amount", slotIndex -> {
            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;

            return switch (slotIndex) {
                case 10 -> SlotProviders.named(Items.PAPER, 64, Text.literal("Buy a stack!"));
                case 12 -> SlotProviders.named(Items.CHEST, 2, Text.literal("Buy a big stack!"));
                case 14 -> SlotProviders.named(Items.CHEST, 16, Text.literal("Buy a thousand!"));
                case 16 -> SlotProviders.named(Items.OAK_SIGN, Text.literal("Custom Amount"));
                case 31 -> SlotProviders.named(Items.ARROW, Text.literal("Go Back"));
                default -> SlotProviders.hiddenTooltip(Items.GRAY_STAINED_GLASS_PANE, 1);
            };
        });
```

~~We could also source the features registered to that view and indicate of whether the slot is occupied or not, but the overlay renderer currently does not indicate/nor supports a slot being "locked" by no state.~~
Implemented as of https://github.com/mkram17/Bazaar-Utils/pull/73/commits/4ecf2ef10266d6785725bcddf68239643c0e43c1

We should also consider refactors needed on ContainerQuery/SlotLookup/BazaarScreens such that those providers could be built off a single definition we'd have per relevant screen. (`Registry`-like API maybe?)

## Item Renderer

Consumed as:
```java
    @ConfigEntry(...)
    @Comment(...)
    @ConfigOption.Renderer("bazaarutils:item")
    public String itemId = "minecraft:barrier";
```

The overlay that pops once clicking the edit button contains by default the whole set of items on Minecraft's Registry. 

It can be filtered via a tag key that should be annotated on the field that consumes the renderer.
```
```java
    @ConfigEntry(...)
    @Comment(...)
    @ItemTag("logs") // filter to the items matched by the "logs" tag
    @ConfigOption.Renderer("bazaarutils:item")
    public String itemId = "minecraft:oak_log";
```

The item registry is currently not augmented by the Hypixel Skyblock items list, but we should look onto that. 

## Decisions we need to take on what features will consume those renderers

If we're going to allow to modify each item of the mods' features and present on each overlay their relevant data, our data objects (on this case, `SmallContainerButton`) will have to become a shallow interface (convexed down to current `ItemButton` interface), for we cannot simply `extend` it and declare a container provider method because ResourcefulConfig does not walk inheritance to build ConfigObjects— we loss the shared properties.

Some features currently style the item buttons they inject depending on feature state. Notably the item to Bookmark a page, and the Input Helpers that are relevant to a pricing position: do we offer a configuration per each possible state? or do we shift through a item group of ours depending on whether the user has selected a specific item that pertains to the scoped tags? (for example: if the user selects a barrier or smth like that, we just render that item no matter what. but if they choose a glass pane or a glass block, we represent state graphically by shifting through selected subset of that category) 

