### PR TITLE
Refactor/widgets

### DIFF
--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/Bookmarks.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/Bookmarks.java
@@ -12,18 +12,17 @@ import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderInfo;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderType;
 import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RegisterWidget;
-import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
 import com.github.mkram17.bazaarutils.utils.config.BUToggleableFeature;
 import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
-import com.github.mkram17.bazaarutils.ui.widgets.ItemSlotButtonWidget;
 import com.github.mkram17.bazaarutils.utils.*;
 import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
-import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderInfo;
-import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.container.ContainerManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.sign.SignManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.ItemSlotButtonWidget;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.WidgetManager;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import meteordevelopment.orbit.EventHandler;
@@ -210,18 +209,13 @@ public class Bookmarks extends BUListener implements ItemButton, BUToggleableFea
 
         List<ItemSlotButtonWidget> widgets = new ArrayList<>();
 
-        boolean isTargetScreen = ScreenManager.getInstance().isCurrent(BazaarScreens.MAIN_PAGE);
-
-        if (!(MinecraftClient.getInstance().currentScreen instanceof AccessorHandledScreen screen) || !isTargetScreen) {
-            return Collections.emptyList();
-        }
-
-        ItemSlotButtonWidget.ScreenWidgetDimensions dimensions = ItemSlotButtonWidget.getSafeScreenDimensions(screen, ContainerManager.getContainerName());
+        var dimensions = WidgetManager.getScreenDimensions(BazaarScreens.ALL.toArray(ScreenType[]::new));
+        if (dimensions.isEmpty()) return Collections.emptyList();
 
         int buttonSize = ButtonsConfig.BookmarksConfig.OPEN_BOOKMARK_BUTTON.size;
         int spacing = ButtonsConfig.BookmarksConfig.OPEN_BOOKMARK_BUTTON.spacing;
-        int buttonX = dimensions.x() + dimensions.backgroundWidth() + spacing;
-        int currentButtonY = dimensions.y() + spacing;
+        int buttonX = dimensions.get().x() + dimensions.get().backgroundWidth() + spacing;
+        int currentButtonY = dimensions.get().y() + spacing;
 
         List<Bookmark> bookmarks = bookmarks();
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/ModButtons.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/ModButtons.java
@@ -6,20 +6,19 @@ import com.github.mkram17.bazaarutils.config.util.ConfigUtil;
 import com.github.mkram17.bazaarutils.generated.BazaarUtilsModules;
 import com.github.mkram17.bazaarutils.utils.PlayerActionUtil;
 import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RegisterWidget;
-import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
-import com.github.mkram17.bazaarutils.ui.widgets.ItemSlotButtonWidget;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.ItemSlotButtonWidget;
 import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.config.BUToggleableFeature;
-import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
-import net.minecraft.client.MinecraftClient;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.WidgetManager;
 import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Module
@@ -45,36 +44,31 @@ public class ModButtons implements BUToggleableFeature {
         return ButtonsConfig.OPEN_ORDERS_BUTTON.enabled || ButtonsConfig.OPEN_SETTINGS_BUTTON.enabled;
     }
 
-    public ModButtons() {};
+    public ModButtons() {}
 
     @RegisterWidget
     public static List<ItemSlotButtonWidget> getWidget() {
+        if (!BazaarUtilsModules.ModButtons.isEnabled()) {
+            return Collections.emptyList();
+        }
+
+        var dimensions = WidgetManager.getScreenDimensions(BazaarScreens.ALL.toArray(ScreenType[]::new));
+        if (dimensions.isEmpty()) return Collections.emptyList();
+
         List<ItemSlotButtonWidget> result = new ArrayList<>();
 
-        if (!BazaarUtilsModules.ModButtons.isEnabled()) {
-            return result;
-        }
-
-        if (!(MinecraftClient.getInstance().currentScreen instanceof AccessorHandledScreen screen) || !ScreenManager.getInstance().isCurrent(BazaarScreens.ALL.toArray(ScreenType[]::new))) {
-            return result;
-        }
-
-        String screenTitle = MinecraftClient.getInstance().currentScreen.getTitle().getString();
-
-        ItemSlotButtonWidget.ScreenWidgetDimensions dimensions = ItemSlotButtonWidget.getSafeScreenDimensions(screen, screenTitle);
-
         if (ButtonsConfig.OPEN_SETTINGS_BUTTON.isEnabled()) {
-            result.add(createModSettingsButtonWidget(dimensions));
+            result.add(createModSettingsButtonWidget(dimensions.get()));
         }
 
         if (ButtonsConfig.OPEN_ORDERS_BUTTON.isEnabled()) {
-            result.add(createBazaarOrdersButtonWidget(dimensions));
+            result.add(createBazaarOrdersButtonWidget(dimensions.get()));
         }
 
         return result;
     }
 
-    private static ItemSlotButtonWidget createModSettingsButtonWidget(ItemSlotButtonWidget.ScreenWidgetDimensions dimensions) {
+    private static ItemSlotButtonWidget createModSettingsButtonWidget(WidgetManager.ScreenWidgetDimensions dimensions) {
         ButtonsConfig.WidgetButton config = ButtonsConfig.OPEN_SETTINGS_BUTTON;
 
         int buttonX = dimensions.x() - config.size - config.spacing;
@@ -91,7 +85,7 @@ public class ModButtons implements BUToggleableFeature {
         );
     }
 
-    private static ItemSlotButtonWidget createBazaarOrdersButtonWidget(ItemSlotButtonWidget.ScreenWidgetDimensions dimensions) {
+    private static ItemSlotButtonWidget createBazaarOrdersButtonWidget(WidgetManager.ScreenWidgetDimensions dimensions) {
         ButtonsConfig.WidgetButton config = ButtonsConfig.OPEN_ORDERS_BUTTON;
 
         int buttonX = dimensions.x() - config.size - config.spacing;

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/overlays/BazaarLimitsVisualizer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/overlays/BazaarLimitsVisualizer.java
@@ -10,20 +10,18 @@ import com.github.mkram17.bazaarutils.data.BazaarLimitsStorage;
 import com.github.mkram17.bazaarutils.events.listener.BUListener;
 import com.github.mkram17.bazaarutils.generated.BazaarUtilsModules;
 import com.github.mkram17.bazaarutils.misc.BUCompatibilityHelper;
+import com.github.mkram17.bazaarutils.utils.Util;
 import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RegisterWidget;
 import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RunOnInit;
-import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
-
-import com.github.mkram17.bazaarutils.ui.widgets.ItemSlotButtonWidget;
-import com.github.mkram17.bazaarutils.ui.widgets.TextDisplayWidget;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.TextDisplayWidget;
 import com.github.mkram17.bazaarutils.utils.TimeUtil;
 import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.config.BUToggleableFeature;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets.WidgetManager;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
@@ -46,8 +44,7 @@ public class BazaarLimitsVisualizer extends BUListener implements BUToggleableFe
         return OverlaysConfig.BAZAAR_LIMITS_VISUALIZER_TOGGLE;
     }
 
-    public BazaarLimitsVisualizer() {
-    }
+    public BazaarLimitsVisualizer() {}
 
     @RunOnInit
     public static void registerBazaarOpen() {
@@ -76,7 +73,7 @@ public class BazaarLimitsVisualizer extends BUListener implements BUToggleableFe
     }
 
     public static void addOrderToLimit(double price) {
-        if (price > Integer.MAX_VALUE){
+        if (price > Integer.MAX_VALUE) {
             price = Integer.MAX_VALUE; // hypixel doesnt count coins over the integer limit
         }
 
@@ -113,17 +110,13 @@ public class BazaarLimitsVisualizer extends BUListener implements BUToggleableFe
             return Collections.emptyList();
         }
 
-        if (!(MinecraftClient.getInstance().currentScreen instanceof AccessorHandledScreen screen) || !ScreenManager.getInstance().isCurrent(BazaarScreens.MAIN_PAGE)) {
-            return Collections.emptyList();
-        }
+        var dimensions = WidgetManager.getScreenDimensions(BazaarScreens.MAIN_PAGE);
+        if (dimensions.isEmpty()) return Collections.emptyList();
 
-        String screenTitle = MinecraftClient.getInstance().currentScreen.getTitle().getString();
-        ItemSlotButtonWidget.ScreenWidgetDimensions dimensions = ItemSlotButtonWidget.getSafeScreenDimensions(screen, screenTitle);
-
-        return List.of(createLimitWidget(dimensions), createTimeUntilResetWidget(dimensions));
+        return List.of(createLimitWidget(dimensions.get()), createTimeUntilResetWidget(dimensions.get()));
     }
 
-    private static TextDisplayWidget createLimitWidget(ItemSlotButtonWidget.ScreenWidgetDimensions dimensions) {
+    private static TextDisplayWidget createLimitWidget(WidgetManager.ScreenWidgetDimensions dimensions) {
         double ordered = BazaarLimitsVisualizer.getTotalOrderedCoins();
         String current = formatNumberWithPrefix(ordered);
         String max = formatNumberWithPrefix(BazaarLimitsVisualizer.COIN_LIMIT);
@@ -141,7 +134,7 @@ public class BazaarLimitsVisualizer extends BUListener implements BUToggleableFe
         return new TextDisplayWidget(x, y, OVERLAY_WIDTH, TEXT_HEIGHT, message, TextDisplayWidget.Alignment.LEFT);
     }
 
-    private static TextDisplayWidget createTimeUntilResetWidget(ItemSlotButtonWidget.ScreenWidgetDimensions dimensions) {
+    private static TextDisplayWidget createTimeUntilResetWidget(WidgetManager.ScreenWidgetDimensions dimensions) {
         ZonedDateTime nextReset = TimeUtil.getNextBazaarLimitReset();
         Duration duration = Duration.between(ZonedDateTime.now(), nextReset);
 
@@ -154,7 +147,7 @@ public class BazaarLimitsVisualizer extends BUListener implements BUToggleableFe
         Text timeText = Text.literal("Until Reset: ").formatted(Formatting.GOLD)
                 .append(Text.literal(timeLabel).formatted(urgencyColor));
 
-        int spacing = BUCompatibilityHelper.isSkyblockerLoaded() ? 26 : 5; 
+        int spacing = BUCompatibilityHelper.isSkyblockerLoaded() ? 26 : 5;
 
         int x = dimensions.x();
         int y = dimensions.y() - spacing - OVERLAY_HEIGHT + TEXT_HEIGHT + LINE_GAP;

--- a/src/main/java/com/github/mkram17/bazaarutils/mixin/AccessorScreen.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/mixin/AccessorScreen.java
@@ -18,14 +18,14 @@ public interface AccessorScreen {
     MinecraftClient getClient();
 
     @Invoker("addDrawableChild")
-    <T extends Element & Drawable & Selectable> T bazaarutils$registerWidget(T widget);
+    <T extends Element & Drawable & Selectable> T registerWidget(T widget);
 
     @Invoker("remove")
-    void bazaarutils$unregisterWidget(Element element);
+    void unregisterWidget(Element element);
 
     @Accessor("drawables")
-    List<Drawable> bazaarutils$getDrawables();
+    List<Drawable> getDrawables();
 
     @Accessor("children")
-    List<Element> bazaarutils$getChildren();
+    List<Element> getChildren();
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/mixin/AccessorScreen.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/mixin/AccessorScreen.java
@@ -1,13 +1,31 @@
 package com.github.mkram17.bazaarutils.mixin;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Drawable;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.List;
 
 //used for SlotClickEvent
 @Mixin(Screen.class)
 public interface AccessorScreen {
     @Accessor("client")
     MinecraftClient getClient();
+
+    @Invoker("addDrawableChild")
+    <T extends Element & Drawable & Selectable> T bazaarutils$registerWidget(T widget);
+
+    @Invoker("remove")
+    void bazaarutils$unregisterWidget(Element element);
+
+    @Accessor("drawables")
+    List<Drawable> bazaarutils$getDrawables();
+
+    @Accessor("children")
+    List<Element> bazaarutils$getChildren();
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/mixin/MixinHandledScreen.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/mixin/MixinHandledScreen.java
@@ -62,13 +62,6 @@ public abstract class MixinHandledScreen extends Screen {
 		}
 	}
 
-	@Inject(method = "init", at = @At("TAIL"))
-	private void addConfiguredButtons(CallbackInfo ci) {
-		for (ClickableWidget button : ConfigUtil.getWidgets()) {
-			this.addDrawableChild(button);
-		}
-	}
-
 	@Inject(method = "drawSlot", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItem(Lnet/minecraft/item/ItemStack;III)V"))
 	private void drawOnItem_OrderStatusHighlight(DrawContext context, Slot slot, int x, int y, CallbackInfo ci) {
 		if (slot == null || !slot.hasStack() || !ScreenManager.getInstance().isCurrent(BazaarScreens.ORDERS_PAGE)) {

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/ItemSlotButtonWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/ItemSlotButtonWidget.java
@@ -1,8 +1,5 @@
-package com.github.mkram17.bazaarutils.ui.widgets;
+package com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets;
 
-import com.github.mkram17.bazaarutils.misc.NotificationType;
-import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
-import com.github.mkram17.bazaarutils.utils.PlayerActionUtil;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.client.gui.tooltip.Tooltip;
@@ -12,7 +9,6 @@ import net.minecraft.text.MutableText;
 
 public class ItemSlotButtonWidget extends TexturedButtonWidget {
     private final ItemStack itemStack;
-    public record ScreenWidgetDimensions(int x, int y, int backgroundWidth) {}
 
     public ItemSlotButtonWidget(int x, int y, int width, int height, ButtonTextures textures, PressAction onPress, ItemStack itemStack, MutableText tooltip) {
         super(x, y, width, height, textures, onPress, net.minecraft.text.Text.empty());
@@ -30,17 +26,5 @@ public class ItemSlotButtonWidget extends TexturedButtonWidget {
 
             context.drawItem(this.itemStack, itemX, itemY);
         }
-    }
-
-    public static ScreenWidgetDimensions getSafeScreenDimensions(AccessorHandledScreen screen, String screenTitle) {
-        int currentX = screen.getX();
-        int currentY = screen.getY();
-        int currentBgWidth = screen.getBackgroundWidth();
-
-        if (currentBgWidth <= 0) {
-            PlayerActionUtil.notifyAll("BackgroundWidth is not yet initialized correctly in init TAIL for " + screenTitle, NotificationType.GUI);
-        }
-
-        return new ScreenWidgetDimensions(currentX, currentY, currentBgWidth);
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/TextDisplayWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/TextDisplayWidget.java
@@ -1,4 +1,4 @@
-package com.github.mkram17.bazaarutils.ui.widgets;
+package com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/WidgetManager.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/WidgetManager.java
@@ -1,0 +1,91 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets;
+
+import com.github.mkram17.bazaarutils.config.util.ConfigUtil;
+import com.github.mkram17.bazaarutils.events.ChestLoadedEvent;
+import com.github.mkram17.bazaarutils.events.ScreenChangeEvent;
+import com.github.mkram17.bazaarutils.events.listener.BUListener;
+import com.github.mkram17.bazaarutils.misc.NotificationType;
+import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
+import com.github.mkram17.bazaarutils.mixin.AccessorScreen;
+import com.github.mkram17.bazaarutils.utils.PlayerActionUtil;
+import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RunOnInit;
+import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
+import com.github.mkram17.bazaarutils.utils.minecraft.gui.container.ContainerManager;
+import meteordevelopment.orbit.EventHandler;
+import meteordevelopment.orbit.EventPriority;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.gui.screen.Screen;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.github.mkram17.bazaarutils.BazaarUtils.EVENT_BUS;
+
+public class WidgetManager {
+    public record ScreenWidgetDimensions(int x, int y, int backgroundWidth) {}
+
+    @RunOnInit
+    public static void initialize() {
+        EVENT_BUS.subscribe(WidgetManager.class);
+    }
+
+    @EventHandler
+    private static void onScreenChange(ScreenChangeEvent event) {
+        if (event.getOldScreen() != null) removeWidgetsFrom(event.getOldScreen());
+
+        // causes a flash when onChestLoaded removes and re-adds immediately after.
+        Screen next = event.getNewScreen();
+        if (next == null || next instanceof GenericContainerScreen) return;
+
+        addWidgetsTo(next);
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    private static void onChestLoaded(ChestLoadedEvent event) {
+        Screen screen = event.getGenericContainerScreen();
+        removeWidgetsFrom(screen);
+        addWidgetsTo(screen);
+    }
+
+    private static void addWidgetsTo(Screen screen) {
+        if (!(screen instanceof AccessorScreen accessor)) return;
+
+        List<ClickableWidget> widgets = ConfigUtil.getWidgets();
+        if (widgets.isEmpty()) return;
+
+        widgets.forEach(accessor::bazaarutils$registerWidget);
+    }
+
+    private static void removeWidgetsFrom(Screen screen) {
+        if (!(screen instanceof AccessorScreen accessor)) return;
+
+        accessor.bazaarutils$getChildren().stream()
+                .filter(element -> element instanceof ItemSlotButtonWidget || element instanceof TextDisplayWidget)
+                .toList()
+                .forEach(accessor::bazaarutils$unregisterWidget);
+    }
+
+    public static Optional<ScreenWidgetDimensions> getScreenDimensions(ScreenType... required) {
+        if (!(MinecraftClient.getInstance().currentScreen instanceof AccessorHandledScreen screen)) {
+            return Optional.empty();
+        }
+
+        if (!ScreenManager.getInstance().isCurrent(required)) {
+            return Optional.empty();
+        }
+
+        int x = screen.getX();
+        int y = screen.getY();
+        int backgroundWidth = screen.getBackgroundWidth();
+
+        if (backgroundWidth <= 0) {
+            PlayerActionUtil.notifyAll("BackgroundWidth not yet initialized for " + ContainerManager.getContainerName(), NotificationType.GUI);
+        }
+
+        return Optional.of(new ScreenWidgetDimensions(x, y, backgroundWidth));
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/WidgetManager.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/gui/widgets/WidgetManager.java
@@ -3,13 +3,11 @@ package com.github.mkram17.bazaarutils.utils.minecraft.gui.widgets;
 import com.github.mkram17.bazaarutils.config.util.ConfigUtil;
 import com.github.mkram17.bazaarutils.events.ChestLoadedEvent;
 import com.github.mkram17.bazaarutils.events.ScreenChangeEvent;
-import com.github.mkram17.bazaarutils.events.listener.BUListener;
 import com.github.mkram17.bazaarutils.misc.NotificationType;
 import com.github.mkram17.bazaarutils.mixin.AccessorHandledScreen;
 import com.github.mkram17.bazaarutils.mixin.AccessorScreen;
 import com.github.mkram17.bazaarutils.utils.PlayerActionUtil;
 import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.RunOnInit;
-import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.container.ContainerManager;
@@ -57,16 +55,16 @@ public class WidgetManager {
         List<ClickableWidget> widgets = ConfigUtil.getWidgets();
         if (widgets.isEmpty()) return;
 
-        widgets.forEach(accessor::bazaarutils$registerWidget);
+        widgets.forEach(accessor::registerWidget);
     }
 
     private static void removeWidgetsFrom(Screen screen) {
         if (!(screen instanceof AccessorScreen accessor)) return;
 
-        accessor.bazaarutils$getChildren().stream()
+        accessor.getChildren().stream()
                 .filter(element -> element instanceof ItemSlotButtonWidget || element instanceof TextDisplayWidget)
                 .toList()
-                .forEach(accessor::bazaarutils$unregisterWidget);
+                .forEach(accessor::unregisterWidget);
     }
 
     public static Optional<ScreenWidgetDimensions> getScreenDimensions(ScreenType... required) {


### PR DESCRIPTION
solves https://github.com/mkram17/Bazaar-Utils/pull/81#issuecomment-4018446773

Rather than to mixin Minecraft's Screen initialization to directly hook our widgets (or even, to be a listener of some event within our systems), we now make public the accessors relevant (drawable childs, etc; https://github.com/mkram17/Bazaar-Utils/commit/e9ca93f7ddee2799e6377348a5bb1df1b579f233) and have a Manager which handles them through screen transitions and required types: https://github.com/mkram17/Bazaar-Utils/pull/82/commits/2ac971d08411006c65def0e1e812e5c58c4e4193.

TODO:
- [x] ~~Consider/come with a system such that widgets positions & size could be configured visually by users~~
  - Should be a separate PR