### PR TITLE
Feat/consume container renderers

### DIFF
--- a/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
@@ -365,6 +365,18 @@ public final class ButtonsConfig {
 
         @Getter
         @ConfigEntry(
+                id = "item_id",
+                translation = "bazaarutils.config.buttons.button.container.item_id.label"
+        )
+        @Comment(
+                value = "The item that will be placed as the button.",
+                translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+        )
+        @ConfigOption.Renderer("bazaarutils:item")
+        public String itemId = "minecraft:green_stained_glass_pane";
+
+        @Getter
+        @ConfigEntry(
                 id = "slot_index",
                 translation = "bazaarutils.config.buttons.button.container.slot_index.label"
         )

--- a/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
@@ -385,6 +385,7 @@ public final class ButtonsConfig {
                 translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
         )
         @ConfigOption.Range(min = 0, max = 35)
+        @ConfigOption.Renderer("bazaarutils:slot")
         public int slotIndex;
 
         public SmallContainerButton(boolean enabled, int slotIndex) {

--- a/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
@@ -12,9 +12,12 @@ import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
 import com.teamresourceful.resourcefulconfig.api.annotations.*;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Category(
         value = "buttons_config",
@@ -112,211 +115,68 @@ public final class ButtonsConfig {
             titleTranslation = "bazaarutils.config.buttons.helpers.category.label"
     )
     public static final class HelpersConfig {
-
-        @ConfigEntry(
-                id = "buy_order_amount",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.label"
+        @ConfigEntry(id = "buy_related_separator")
+        @ConfigOption.Hidden
+        @ConfigOption.Separator(
+                value = "bazaarutils.config.buttons.helpers.separator.buy_related.label",
+                description = "bazaarutils.config.buttons.helpers.separator.buy_related.hint"
         )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the amount for this order the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.buy_order_amount.separator.label")
-        public static boolean BUY_ORDER_AMOUNT_TOGGLE = true;
-
-        @ConfigEntry(
-                id = "first_buy_order_amount",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.1.label"
-        )
-        public static final BuyOrderAmountHelper FIRST_BUY_ORDER_AMOUNT = new BuyOrderAmountHelper(true, 17);
-
-        @ConfigEntry(
-                id = "second_buy_order_amount",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.2.label"
-        )
-        public static final BuyOrderAmountHelper SECOND_BUY_ORDER_AMOUNT = new BuyOrderAmountHelper(false, 8);
-
-        @ConfigEntry(
-                id = "third_buy_order_amount",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.3.label"
-        )
-        public static final BuyOrderAmountHelper THIRD_BUY_ORDER_AMOUNT = new BuyOrderAmountHelper(false, 26);
+        public static boolean HELPERS_BUY_RELATED_SEPARATOR = true;
 
         @ConfigEntry(
                 id = "instant_buy_amount",
                 translation = "bazaarutils.config.buttons.helpers.instant_buy_amount.label"
         )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the amount for this purchase the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.instant_buy_amount.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.instant_buy_amount.separator.label")
-        public static boolean INSTANT_BUY_AMOUNT_TOGGLE = true;
+        public static final List<InstantBuyAmountHelper> HELPERS_INSTANT_BUY_AMOUNT_BUTTONS = new ArrayList<>(List.of(new InstantBuyAmountHelper(17)));
 
         @ConfigEntry(
-                id = "first_instant_buy_amount",
-                translation = "bazaarutils.config.buttons.helpers.instant_buy_amount.1.label"
+                id = "buy_order_amount",
+                translation = "bazaarutils.config.buttons.helpers.buy_order_amount.label"
         )
-        public static final InstantBuyAmountHelper FIRST_INSTANT_BUY_AMOUNT = new InstantBuyAmountHelper(true, 17);
-
-        @ConfigEntry(
-                id = "second_instant_buy_amount",
-                translation = "bazaarutils.config.buttons.helpers.instant_buy_amount.2.label"
-        )
-        public static final InstantBuyAmountHelper SECOND_INSTANT_BUY_AMOUNT = new InstantBuyAmountHelper(false, 8);
-
-        @ConfigEntry(
-                id = "third_instant_buy_amount",
-                translation = "bazaarutils.config.buttons.helpers.instant_buy_amount.3.label"
-        )
-        public static final InstantBuyAmountHelper THIRD_INSTANT_BUY_AMOUNT = new InstantBuyAmountHelper(false, 26);
-
-        @ConfigEntry(
-                id = "sell_offer_amount",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.label"
-        )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the amount for this offer the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.sell_offer_amount.separator.label")
-        public static boolean SELL_OFFER_AMOUNT_TOGGLE = true;
-
-        @ConfigEntry(
-                id = "first_sell_offer_amount",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.1.label"
-        )
-        public static final SellOfferAmountHelper FIRST_SELL_OFFER_AMOUNT = new SellOfferAmountHelper(true, 17);
-
-        @ConfigEntry(
-                id = "second_sell_offer_amount",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.2.label"
-        )
-        public static final SellOfferAmountHelper SECOND_SELL_OFFER_AMOUNT = new SellOfferAmountHelper(false, 8);
-
-        @ConfigEntry(
-                id = "third_sell_offer_amount",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.3.label"
-        )
-        public static final SellOfferAmountHelper THIRD_SELL_OFFER_AMOUNT = new SellOfferAmountHelper(false, 26);
+        public static final List<BuyOrderAmountHelper> HELPERS_BUY_ORDER_AMOUNT_BUTTONS = new ArrayList<>(List.of(new BuyOrderAmountHelper(17)));
 
         @ConfigEntry(
                 id = "buy_order_price",
                 translation = "bazaarutils.config.buttons.helpers.buy_order_price.label"
         )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the price for this order the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_price.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.buy_order_price.separator.label")
-        public static boolean BUY_ORDER_PRICE_TOGGLE = true;
+        public static final List<BuyOrderPriceHelper> HELPERS_BUY_ORDER_PRICE_BUTTONS = new ArrayList<>(List.of(new BuyOrderPriceHelper(17, PricingPosition.COMPETITIVE)));
 
-        @ConfigEntry(
-                id = "first_buy_order_price",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_price.1.label"
+        @ConfigEntry(id = "sell_related_separator")
+        @ConfigOption.Hidden
+        @ConfigOption.Separator(
+                value = "bazaarutils.config.buttons.helpers.separator.sell_related.label",
+                description = "bazaarutils.config.buttons.helpers.separator.sell_related.hint"
         )
-        public static final BuyOrderPriceHelper FIRST_BUY_ORDER_PRICE = new BuyOrderPriceHelper(true, 17, PricingPosition.COMPETITIVE);
-
-        @ConfigEntry(
-                id = "second_buy_order_price",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_price.2.label"
-        )
-        public static final BuyOrderPriceHelper SECOND_BUY_ORDER_PRICE = new BuyOrderPriceHelper(false, 8, PricingPosition.MATCHED);
-
-        @ConfigEntry(
-                id = "third_buy_order_price",
-                translation = "bazaarutils.config.buttons.helpers.buy_order_price.3.label"
-        )
-        public static final BuyOrderPriceHelper THIRD_BUY_ORDER_PRICE = new BuyOrderPriceHelper(false, 26, PricingPosition.OUTBID);
-
-        @ConfigEntry(
-                id = "sell_offer_price",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.label"
-        )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the price for this offer the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.sell_offer_price.separator.label")
-        public static boolean SELL_OFFER_PRICE_TOGGLE = true;
-
-        @ConfigEntry(
-                id = "first_sell_offer_price",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.1.label"
-        )
-        public static final SellOfferPriceHelper FIRST_SELL_OFFER_PRICE = new SellOfferPriceHelper(true, 17, PricingPosition.COMPETITIVE);
-
-        @ConfigEntry(
-                id = "second_sell_offer_price",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.2.label"
-        )
-        public static final SellOfferPriceHelper SECOND_SELL_OFFER_PRICE = new SellOfferPriceHelper(false, 8, PricingPosition.MATCHED);
-
-        @ConfigEntry(
-                id = "third_sell_offer_price",
-                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.3.label"
-        )
-        public static final SellOfferPriceHelper THIRD_SELL_OFFER_PRICE = new SellOfferPriceHelper(false, 26, PricingPosition.OUTBID);
+        public static boolean HELPERS_SELL_RELATED_SEPARATOR = true;
 
         @ConfigEntry(
                 id = "flip_order_price",
                 translation = "bazaarutils.config.buttons.helpers.flip_order_price.label"
         )
-        @Comment(
-                value = "Places an item at the desired slot, which when clicked will input as the price for this flip the computed, configurable, value.",
-                translation = "bazaarutils.config.buttons.helpers.flip_order_price.hint"
-        )
-        @ConfigOption.Separator(value = "bazaarutils.config.buttons.helpers.flip_order_price.separator.label")
-        public static boolean FLIP_ORDER_PRICE_TOGGLE = true;
+        public static final List<FlipOrderPriceHelper> HELPERS_FLIP_ORDER_PRICE_BUTTONS = new ArrayList<>(List.of(new FlipOrderPriceHelper(17, PricingPosition.COMPETITIVE)));
 
         @ConfigEntry(
-                id = "first_flip_order_price",
-                translation = "bazaarutils.config.buttons.helpers.flip_order_price.1.label"
+                id = "sell_offer_amount",
+                translation = "bazaarutils.config.buttons.helpers.sell_offer_amount.label"
         )
-        public static final FlipOrderPriceHelper FIRST_FLIP_ORDER_PRICE = new FlipOrderPriceHelper(true, 17, PricingPosition.COMPETITIVE);
+        public static final List<SellOfferAmountHelper> HELPERS_SELL_OFFER_AMOUNT_BUTTONS = new ArrayList<>(List.of(new SellOfferAmountHelper(17)));
 
         @ConfigEntry(
-                id = "second_flip_order_price",
-                translation = "bazaarutils.config.buttons.helpers.flip_order_price.2.label"
+                id = "sell_offer_price",
+                translation = "bazaarutils.config.buttons.helpers.sell_offer_price.label"
         )
-        public static final FlipOrderPriceHelper SECOND_FLIP_ORDER_PRICE = new FlipOrderPriceHelper(false, 8, PricingPosition.MATCHED);
-
-        @ConfigEntry(
-                id = "third_flip_order_price",
-                translation = "bazaarutils.config.buttons.helpers.flip_order_price.3.label"
-        )
-        public static final FlipOrderPriceHelper THIRD_FLIP_ORDER_PRICE = new FlipOrderPriceHelper(false, 26, PricingPosition.OUTBID);
-
-        public static final SignInputHelper.TransactionAmount[] AMOUNT_HELPERS = {
-                FIRST_BUY_ORDER_AMOUNT,
-                SECOND_BUY_ORDER_AMOUNT,
-                THIRD_BUY_ORDER_AMOUNT,
-                FIRST_INSTANT_BUY_AMOUNT,
-                SECOND_INSTANT_BUY_AMOUNT,
-                THIRD_INSTANT_BUY_AMOUNT,
-                FIRST_SELL_OFFER_AMOUNT,
-                SECOND_SELL_OFFER_AMOUNT,
-                THIRD_SELL_OFFER_AMOUNT
-        };
+        public static final List<SellOfferPriceHelper> HELPERS_SELL_OFFER_PRICE_BUTTONS = new ArrayList<>(List.of(new SellOfferPriceHelper(17, PricingPosition.COMPETITIVE)));
 
         public static List<SignInputHelper.TransactionAmount> amountHelpers() {
-            return Arrays.stream(AMOUNT_HELPERS).collect(Collectors.toList());
+            return Stream.of(HELPERS_INSTANT_BUY_AMOUNT_BUTTONS, HELPERS_BUY_ORDER_AMOUNT_BUTTONS, HELPERS_SELL_OFFER_AMOUNT_BUTTONS)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
         }
 
-        public static final SignInputHelper.TransactionCost[] PRICE_HELPERS = {
-                FIRST_BUY_ORDER_PRICE,
-                SECOND_BUY_ORDER_PRICE,
-                THIRD_BUY_ORDER_PRICE,
-                FIRST_SELL_OFFER_PRICE,
-                SECOND_SELL_OFFER_PRICE,
-                THIRD_SELL_OFFER_PRICE,
-                FIRST_FLIP_ORDER_PRICE,
-                SECOND_FLIP_ORDER_PRICE,
-                THIRD_FLIP_ORDER_PRICE
-        };
-
         public static List<SignInputHelper.TransactionCost> priceHelpers() {
-            return Arrays.stream(PRICE_HELPERS).collect(Collectors.toList());
+            return Stream.of(HELPERS_FLIP_ORDER_PRICE_BUTTONS, HELPERS_BUY_ORDER_PRICE_BUTTONS, HELPERS_SELL_OFFER_PRICE_BUTTONS)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
         }
     }
 
@@ -337,7 +197,7 @@ public final class ButtonsConfig {
                 id = "size",
                 translation = "bazaarutils.config.buttons.button.widget.size.label"
         )
-        public int size = 18;
+        public int size = 117;
 
         @ConfigEntry(
                 id = "spacing",

--- a/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/features/gui/ButtonsConfig.java
@@ -365,19 +365,19 @@ public final class ButtonsConfig {
 
         @Getter
         @ConfigEntry(
-                id = "slot_number",
-                translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+                id = "slot_index",
+                translation = "bazaarutils.config.buttons.button.container.slot_index.label"
         )
         @Comment(
                 value = "The container slot where the button will be registered at",
-                translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+                translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
         )
         @ConfigOption.Range(min = 0, max = 35)
-        public int slotNumber;
+        public int slotIndex;
 
-        public SmallContainerButton(boolean enabled, int slotNumber) {
+        public SmallContainerButton(boolean enabled, int slotIndex) {
             this.enabled = enabled;
-            this.slotNumber = slotNumber;
+            this.slotIndex = slotIndex;
         }
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/ConfigUtil.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/ConfigUtil.java
@@ -3,6 +3,8 @@ package com.github.mkram17.bazaarutils.config.util;
 import com.github.mkram17.bazaarutils.BazaarUtils;
 import com.github.mkram17.bazaarutils.config.BUConfig;
 import com.github.mkram17.bazaarutils.config.patcher.ConfigPatches;
+import com.github.mkram17.bazaarutils.config.util.client.ItemRendererProvider;
+import com.github.mkram17.bazaarutils.config.util.client.SlotRendererProvider;
 import com.github.mkram17.bazaarutils.utils.Util;
 import com.google.gson.JsonObject;
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigScreen;
@@ -62,6 +64,9 @@ public class ConfigUtil {
                             "— expected VERSION = " + (PATCHES.size() + 1)
             );
         }
+        
+        ItemRendererProvider.register();
+        SlotRendererProvider.register();
 
         configurator.register(BUConfig.class, event ->
                 PATCHES.forEach((version, patch) ->

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ItemElement.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ItemElement.java
@@ -1,0 +1,123 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ItemTag;
+import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
+import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.ResourcefulConfigElement;
+import com.teamresourceful.resourcefulconfig.api.types.elements.ResourcefulConfigEntryElement;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import com.teamresourceful.resourcefulconfig.api.types.options.EntryType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+public final class ItemElement implements ResourcefulConfigEntryElement {
+    private final ResourcefulConfigEntryElement delegate;
+
+    private final String tag;
+
+    private ItemElement(ResourcefulConfigEntryElement delegate, String tag) {
+        this.delegate = delegate;
+        this.tag = tag;
+    }
+
+    public static ItemElement wrap(ResourcefulConfigElement element) {
+        if (!(element instanceof ResourcefulConfigEntryElement entry)) return null;
+        if (!(entry.entry() instanceof ResourcefulConfigValueEntry value)) return null;
+        if (!(value.type() == EntryType.STRING)) return null;
+
+        Field field = entryField(entry);
+
+        if (field == null) return null;
+
+        String tag = field.isAnnotationPresent(ItemTag.class) ? field.getAnnotation(ItemTag.class).value() : "";
+
+        return new ItemElement(entry, tag);
+    }
+
+    private static Field entryField(ResourcefulConfigEntryElement delegate) {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    public String tag() {
+        return tag;
+    }
+
+    public ResourcefulConfigValueEntry valueEntry() {
+        return (ResourcefulConfigValueEntry) delegate.entry();
+    }
+
+    public Text title() {
+        Field field = entryField();
+
+        if (field != null) {
+            ConfigEntry options = field.getAnnotation(ConfigEntry.class);
+
+            if (options != null && !options.translation().isEmpty()) {
+                return Text.translatable(options.translation());
+            }
+        }
+
+        return Text.literal(delegate.id());
+    }
+
+    public Text description() {
+        Field field = entryField();
+
+        if (field != null) {
+            Comment comment = field.getAnnotation(Comment.class);
+
+            if (comment != null) {
+                return !comment.translation().isEmpty()
+                        ? Text.translatable(comment.translation())
+                        : Text.literal(comment.value());
+            }
+        }
+
+        return Text.empty();
+    }
+
+    @Override public ResourcefulConfigEntry entry() {
+        return delegate.entry();
+    }
+
+    @Override public String id() {
+        return delegate.id();
+    }
+
+    @Override public Identifier renderer() {
+        return delegate.renderer();
+    }
+
+    @Override public boolean isHidden() {
+        return delegate.isHidden();
+    }
+
+    @Override public boolean search(Predicate<String> predicate) {
+        return delegate.search(predicate);
+    }
+
+    private Field entryField() {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
@@ -1,0 +1,41 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+public final class ResourcefulConfigItems {
+    private static Supplier<List<Item>> source = () -> Registries.ITEM.stream().toList();
+
+    private static Predicate<Item> globalFilter = item -> true;
+
+    private ResourcefulConfigItems() {}
+
+    public static void setSource(Supplier<List<Item>> source) {
+        ResourcefulConfigItems.source = source;
+    }
+
+    public static void addGlobalFilter(Predicate<Item> filter) {
+        Predicate<Item> existing = ResourcefulConfigItems.globalFilter;
+        ResourcefulConfigItems.globalFilter = item -> existing.test(item) && filter.test(item);
+    }
+
+    public static List<Item> getItems(String tag) {
+        List<Item> base = source.get().stream().filter(globalFilter).toList();
+        if (tag == null || tag.isEmpty()) return base;
+        Identifier tagId = Identifier.tryParse(tag);
+        if (tagId == null) return base;
+        TagKey<Item> tagKey = TagKey.of(RegistryKeys.ITEM, tagId);
+        return base.stream().filter(item -> item.getRegistryEntry().isIn(tagKey)).toList();
+    }
+
+    public static List<Item> getItems() {
+        return getItems("");
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/ResourcefulConfigItems.java
@@ -5,26 +5,48 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public final class ResourcefulConfigItems {
+    private static final Map<String, Item> RESOLVED_CACHE = new HashMap<>();
+
+    public static @Nullable Item resolve(String rawId) {
+        if (rawId == null || rawId.isEmpty()) return null;
+
+        return RESOLVED_CACHE.computeIfAbsent(rawId, id -> {
+            Identifier identifier = Identifier.tryParse(id);
+
+            if (identifier == null) return null;
+
+            return source.get().stream()
+                    .filter(item -> Registries.ITEM.getId(item).equals(identifier))
+                    .findFirst()
+                    .orElse(null);
+        });
+    }
+
+
     private static Supplier<List<Item>> source = () -> Registries.ITEM.stream().toList();
-
-    private static Predicate<Item> globalFilter = item -> true;
-
-    private ResourcefulConfigItems() {}
 
     public static void setSource(Supplier<List<Item>> source) {
         ResourcefulConfigItems.source = source;
     }
 
+    private static Predicate<Item> globalFilter = item -> true;
+
     public static void addGlobalFilter(Predicate<Item> filter) {
         Predicate<Item> existing = ResourcefulConfigItems.globalFilter;
         ResourcefulConfigItems.globalFilter = item -> existing.test(item) && filter.test(item);
     }
+
+
+    private ResourcefulConfigItems() {}
 
     public static List<Item> getItems(String tag) {
         List<Item> base = source.get().stream().filter(globalFilter).toList();

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotElement.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotElement.java
@@ -1,0 +1,127 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
+import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
+import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.ResourcefulConfigElement;
+import com.teamresourceful.resourcefulconfig.api.types.elements.ResourcefulConfigEntryElement;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigEntry;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import com.teamresourceful.resourcefulconfig.api.types.options.EntryType;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+public final class SlotElement implements ResourcefulConfigEntryElement {
+    private final ResourcefulConfigEntryElement delegate;
+
+    private final int rows;
+    private final int cols;
+
+    private final SlotProvider provider;
+
+    private SlotElement(ResourcefulConfigEntryElement delegate, int rows, int cols, SlotProvider provider) {
+        this.delegate = delegate;
+        this.rows = rows;
+        this.cols = cols;
+        this.provider = provider;
+    }
+
+    public static SlotElement wrap(ResourcefulConfigElement element) {
+        if (!(element instanceof ResourcefulConfigEntryElement entry)) return null;
+        if (!(entry.entry() instanceof ResourcefulConfigValueEntry value)) return null;
+        if (value.type() != EntryType.INTEGER) return null;
+
+        Field field = entryField(entry);
+
+        if (field == null || !field.isAnnotationPresent(ContainerSlot.class)) return null;
+
+        ContainerSlot options = field.getAnnotation(ContainerSlot.class);
+        SlotProvider provider = SlotProviders.get(options.provider());
+
+        return new SlotElement(entry, options.rows(), options.cols(), provider);
+    }
+
+    public int rows() {
+        return rows;
+    }
+
+    public int cols() {
+        return cols;
+    }
+
+    public int totalSlots() {
+        return rows * cols;
+    }
+
+    public SlotProvider provider() {
+        return provider;
+    }
+
+    public ResourcefulConfigValueEntry valueEntry() {
+        return (ResourcefulConfigValueEntry) delegate.entry();
+    }
+
+    public Text title() {
+        Field field = entryField(delegate);
+
+        if (field != null) {
+            ConfigEntry options = field.getAnnotation(ConfigEntry.class);
+
+            if (options != null && !options.translation().isEmpty()) return Text.translatable(options.translation());
+        }
+
+        return Text.literal(delegate.id());
+    }
+
+    public Text description() {
+        Field field = entryField(delegate);
+
+        if (field != null) {
+            Comment comment = field.getAnnotation(Comment.class);
+
+            if (comment != null) {
+                return !comment.translation().isEmpty()
+                        ? Text.translatable(comment.translation())
+                        : Text.literal(comment.value());
+            }
+        }
+
+        return Text.empty();
+    }
+
+    @Override public ResourcefulConfigEntry entry() {
+        return delegate.entry();
+    }
+
+    @Override public String id() {
+        return delegate.id();
+    }
+
+    @Override public Identifier renderer() {
+        return delegate.renderer();
+    }
+
+    @Override public boolean isHidden() {
+        return delegate.isHidden();
+    }
+
+    @Override public boolean search(Predicate<String> predicate) {
+        return delegate.search(predicate);
+    }
+
+    private static Field entryField(ResourcefulConfigEntryElement delegate) {
+        try {
+            Method field = delegate.entry().getClass().getDeclaredMethod("field");
+
+            field.setAccessible(true);
+
+            return (Field) field.invoke(delegate.entry());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
@@ -1,0 +1,8 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import net.minecraft.item.ItemStack;
+
+@FunctionalInterface
+public interface SlotProvider {
+    ItemStack getStack(int slotIndex);
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProvider.java
@@ -4,5 +4,9 @@ import net.minecraft.item.ItemStack;
 
 @FunctionalInterface
 public interface SlotProvider {
-    ItemStack getStack(int slotIndex);
+    ItemStack getStack(int slotIndex, int selectedSlotIndex);
+
+    default ItemStack getStack(int slotIndex) {
+        return getStack(slotIndex, -1);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,0 +1,46 @@
+package com.github.mkram17.bazaarutils.config.util.api;
+
+import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SlotProviders {
+    private static final Map<String, SlotProvider> REGISTRY = new HashMap<>();
+
+    private SlotProviders() {}
+
+    public static void register(String key, SlotProvider provider) {
+        REGISTRY.put(key, provider);
+    }
+
+    public static SlotProvider get(String key) {
+        if (key == null || key.isEmpty()) return slot -> ItemStack.EMPTY;
+
+        return REGISTRY.getOrDefault(key, slot -> ItemStack.EMPTY);
+    }
+
+    public static ItemStack named(Item item, Text name) {
+        return named(item, 1, name);
+    }
+
+    public static ItemStack named(Item item, int count, Text name) {
+        ItemStack stack = new ItemStack(item, count);
+        stack.set(DataComponentTypes.CUSTOM_NAME, name);
+
+        return stack;
+    }
+
+    public static ItemStack hiddenTooltip(Item item, int count) {
+        ItemStack stack = new ItemStack(item, count);
+
+        stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, new ReferenceLinkedOpenHashSet<>()));
+
+        return stack;
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,6 +1,7 @@
 package com.github.mkram17.bazaarutils.config.util.api;
 
 import com.github.mkram17.bazaarutils.BazaarUtils;
+import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.component.DataComponentTypes;
@@ -10,7 +11,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 public final class SlotProviders {
     private static final Map<String, SlotProvider> REGISTRY = new HashMap<>();
@@ -21,10 +25,34 @@ public final class SlotProviders {
         REGISTRY.put(key, provider);
     }
 
-    public static SlotProvider get(String key) {
-        if (key == null || key.isEmpty()) return slot -> ItemStack.EMPTY;
+    public static void registerDynamic(String key, Supplier<List<? extends ItemButton>> entries, SlotProvider provider) {
+        register(key, (slotIndex, selectedSlotIndex) -> {
+            Optional<? extends ItemButton> occupant = entries.get().stream()
+                    .filter(entry -> entry.getSlotIndex() == slotIndex)
+                    .findFirst();
 
-        return REGISTRY.getOrDefault(key, slot -> ItemStack.EMPTY);
+            if (occupant.isPresent()) {
+                int occupantIndex = entries.get().indexOf(occupant.get()) + 1;
+
+                boolean isSelf = occupant.get().getSlotIndex() == selectedSlotIndex;
+
+                return stack(occupant.get().resolveItem())
+                        .named(isSelf
+                                ? "Currently selected slot"
+                                : "Slot taken by Button #" + occupantIndex
+                        )
+                        .locked()
+                        .build();
+            }
+
+            return provider.getStack(slotIndex, selectedSlotIndex);
+        });
+    }
+
+    public static SlotProvider get(String key) {
+        if (key == null || key.isEmpty()) return (slotIndex, selectedSlotIndex) -> ItemStack.EMPTY;
+
+        return REGISTRY.getOrDefault(key, (slotIndex, selectedSlotIndex) -> ItemStack.EMPTY);
     }
 
     public static SlotStack stack(Item item) {

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,13 +1,9 @@
 package com.github.mkram17.bazaarutils.config.util.api;
 
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemBuilder;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
-import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
-import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.text.Text;
 
 import java.util.HashMap;
 import java.util.List;
@@ -54,53 +50,11 @@ public final class SlotProviders {
         return REGISTRY.getOrDefault(key, (slotIndex, selectedSlotIndex) -> ItemStack.EMPTY);
     }
 
-    public static SlotStack stack(Item item) {
-        return new SlotStack(item, 1);
+    public static ItemBuilder stack(Item item) {
+        return ItemBuilder.of(item);
     }
 
-    public static SlotStack stack(Item item, int count) {
-        return new SlotStack(item, count);
-    }
-
-    public static final class SlotStack {
-
-        private final ItemStack stack;
-
-        private SlotStack(Item item, int count) {
-            this.stack = new ItemStack(item, count);
-        }
-
-        public SlotStack named(Text name) {
-            stack.set(DataComponentTypes.CUSTOM_NAME, name);
-            return this;
-        }
-
-        public SlotStack named(String name) {
-            return named(Text.literal(name));
-        }
-
-        public SlotStack locked() {
-            stack.set(CustomDataComponents.SLOT_SELECTOR_LOCKED, true);
-            return this;
-        }
-
-        public SlotStack hideTooltip() {
-            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, ReferenceSortedSets.emptySet()));
-            return this;
-        }
-
-//      we hide attributes by default
-//        public SlotStack hideAttributes() {
-//            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
-//            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
-//            return this;
-//        }
-
-        public ItemStack build() {
-            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
-            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
-
-            return stack;
-        }
+    public static ItemBuilder stack(Item item, int count) {
+        return ItemBuilder.of(item, count);
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,7 +1,6 @@
 package com.github.mkram17.bazaarutils.config.util.api;
 
-import com.github.mkram17.bazaarutils.BazaarUtils;
-import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.component.DataComponentTypes;

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/SlotProviders.java
@@ -1,6 +1,8 @@
 package com.github.mkram17.bazaarutils.config.util.api;
 
-import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import com.github.mkram17.bazaarutils.BazaarUtils;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
+import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.TooltipDisplayComponent;
 import net.minecraft.item.Item;
@@ -25,22 +27,53 @@ public final class SlotProviders {
         return REGISTRY.getOrDefault(key, slot -> ItemStack.EMPTY);
     }
 
-    public static ItemStack named(Item item, Text name) {
-        return named(item, 1, name);
+    public static SlotStack stack(Item item) {
+        return new SlotStack(item, 1);
     }
 
-    public static ItemStack named(Item item, int count, Text name) {
-        ItemStack stack = new ItemStack(item, count);
-        stack.set(DataComponentTypes.CUSTOM_NAME, name);
-
-        return stack;
+    public static SlotStack stack(Item item, int count) {
+        return new SlotStack(item, count);
     }
 
-    public static ItemStack hiddenTooltip(Item item, int count) {
-        ItemStack stack = new ItemStack(item, count);
+    public static final class SlotStack {
 
-        stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, new ReferenceLinkedOpenHashSet<>()));
+        private final ItemStack stack;
 
-        return stack;
+        private SlotStack(Item item, int count) {
+            this.stack = new ItemStack(item, count);
+        }
+
+        public SlotStack named(Text name) {
+            stack.set(DataComponentTypes.CUSTOM_NAME, name);
+            return this;
+        }
+
+        public SlotStack named(String name) {
+            return named(Text.literal(name));
+        }
+
+        public SlotStack locked() {
+            stack.set(CustomDataComponents.SLOT_SELECTOR_LOCKED, true);
+            return this;
+        }
+
+        public SlotStack hideTooltip() {
+            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, new TooltipDisplayComponent(true, ReferenceSortedSets.emptySet()));
+            return this;
+        }
+
+//      we hide attributes by default
+//        public SlotStack hideAttributes() {
+//            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
+//            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
+//            return this;
+//        }
+
+        public ItemStack build() {
+            TooltipDisplayComponent current = stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
+            stack.set(DataComponentTypes.TOOLTIP_DISPLAY, current.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
+
+            return stack;
+        }
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ContainerSlot.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ContainerSlot.java
@@ -1,0 +1,15 @@
+package com.github.mkram17.bazaarutils.config.util.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ContainerSlot {
+    int rows();
+    int cols();
+
+    String provider() default "";
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ItemTag.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/api/annotations/ItemTag.java
@@ -1,0 +1,12 @@
+package com.github.mkram17.bazaarutils.config.util.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ItemTag {
+    String value();
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
@@ -37,9 +37,10 @@ public record ItemRenderer(ItemElement element) implements ResourcefulConfigElem
         ItemStringOptionWidget stringWidget = new ItemStringOptionWidget(
                 entry::getString,
                 s -> {
-                    Identifier id = Identifier.tryParse(s);
-                    if (id == null) return false;
-                    if (items.stream().noneMatch(item -> Registries.ITEM.getId(item).equals(id))) return false;
+                    Item resolved = ResourcefulConfigItems.resolve(s);
+
+                    if (resolved == null || !items.contains(resolved)) return false;
+
                     entry.setString(s);
                     return true;
                 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRenderer.java
@@ -1,0 +1,57 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.ItemElement;
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.ItemOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.ItemStringOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.ResetOptionWidget;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigElementRenderer;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public record ItemRenderer(ItemElement element) implements ResourcefulConfigElementRenderer {
+    @Override
+    public Text title() {
+        return element.title();
+    }
+
+    @Override
+    public Text description() {
+        return element.description();
+    }
+
+    @Override
+    public List<ClickableWidget> widgets() {
+        ResourcefulConfigValueEntry entry = element.valueEntry();
+
+        List<Item> items = ResourcefulConfigItems.getItems(element.tag());
+
+        ItemOptionWidget itemWidget = new ItemOptionWidget(items, entry::getString, entry::setString);
+
+        ItemStringOptionWidget stringWidget = new ItemStringOptionWidget(
+                entry::getString,
+                s -> {
+                    Identifier id = Identifier.tryParse(s);
+                    if (id == null) return false;
+                    if (items.stream().noneMatch(item -> Registries.ITEM.getId(item).equals(id))) return false;
+                    entry.setString(s);
+                    return true;
+                }
+        );
+
+        return List.of(
+                itemWidget,
+                stringWidget,
+                ResetOptionWidget.of(() -> {
+                    entry.reset();
+                    stringWidget.reset();
+                })
+        );
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/ItemRendererProvider.java
@@ -1,0 +1,19 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.ItemElement;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
+import net.minecraft.util.Identifier;
+
+public final class ItemRendererProvider {
+    private ItemRendererProvider() {}
+
+    public static void register() {
+        ResourcefulConfigUI.registerElementRenderer(
+                Identifier.of("bazaarutils", "item"),
+                element -> {
+                    ItemElement ie = ItemElement.wrap(element);
+                    return ie != null ? new ItemRenderer(ie) : null;
+                }
+        );
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRenderer.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRenderer.java
@@ -1,0 +1,44 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.ResetOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.SlotNumberOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.SlotOptionWidget;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigElementRenderer;
+import com.teamresourceful.resourcefulconfig.api.types.entries.ResourcefulConfigValueEntry;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.text.Text;
+
+import java.util.List;
+
+public record SlotRenderer(SlotElement element) implements ResourcefulConfigElementRenderer {
+    @Override
+    public Text title() {
+        return element.title();
+    }
+
+    @Override
+    public Text description() {
+        return element.description();
+    }
+
+    @Override
+    public List<ClickableWidget> widgets() {
+        ResourcefulConfigValueEntry entry = element.valueEntry();
+
+        SlotOptionWidget slotWidget = new SlotOptionWidget(
+                element,
+                entry::getInt,
+                entry::setInt
+        );
+
+        SlotNumberOptionWidget numberWidget = new SlotNumberOptionWidget(element);
+
+        ClickableWidget resetWidget = ResetOptionWidget.of(() -> {
+            entry.reset();
+            numberWidget.reset();
+        });
+
+        return List.of(slotWidget, numberWidget, resetWidget);
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
@@ -3,7 +3,6 @@ package com.github.mkram17.bazaarutils.config.util.client;
 import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
 import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
-import com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount.BuyOrderAmountHelper;
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -25,34 +24,42 @@ public final class SlotRendererProvider {
     }
 
     private static void registerElementProviders() {
-        SlotProviders.register("bazaar:buy_order_amount", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+        SlotProviders.registerDynamic(
+                "bazaar:buy_order_amount",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_BUY_ORDER_AMOUNT_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-            return switch (slotIndex) {
-                case 10 -> SlotProviders.stack(Items.PAPER,64).named("Buy a stack!").locked().build();
-                case 12 -> SlotProviders.stack(Items.CHEST,2).named("Buy a big stack!").locked().build();
-                case 14 -> SlotProviders.stack(Items.CHEST,16).named("Buy a thousand!").locked().build();
-                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
-                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
+                    return switch (slotIndex) {
+                        case 10 -> SlotProviders.stack(Items.PAPER, 64).named("Buy a stack!").locked().build();
+                        case 12 -> SlotProviders.stack(Items.CHEST, 2).named("Buy a big stack!").locked().build();
+                        case 14 -> SlotProviders.stack(Items.CHEST, 16).named("Buy a thousand!").locked().build();
+                        case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                        case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
 
-        SlotProviders.register("bazaar:buy_order_price", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+        SlotProviders.registerDynamic(
+                "bazaar:buy_order_price",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_BUY_ORDER_PRICE_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-            return switch (slotIndex) {
-                case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Top Order").locked().build();
-                case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Top Order +0.1").locked().build();
-                case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("5% of Spread").locked().build();
-                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
-                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Buy Order").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
+                    return switch (slotIndex) {
+                        case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Top Order").locked().build();
+                        case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Top Order +0.1").locked().build();
+                        case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("5% of Spread").locked().build();
+                        case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
+                        case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Buy Order").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
 
-        SlotProviders.register("bazaar:buy_order_confirmation", slotIndex -> {
+        SlotProviders.register("bazaar:buy_order_confirmation", (slotIndex, selectedSlot) -> {
             if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
             return switch (slotIndex) {
@@ -63,48 +70,59 @@ public final class SlotRendererProvider {
             };
         });
 
+        SlotProviders.registerDynamic(
+                "bazaar:instant_buy_amount",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_INSTANT_BUY_AMOUNT_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-        SlotProviders.register("bazaar:instant_buy_amount", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+                    return switch (slotIndex) {
+                        case 10 -> SlotProviders.stack(Items.PAPER).named("Buy only one!").locked().build();
+                        case 12 -> SlotProviders.stack(Items.PAPER, 64).named("Buy a stack!").locked().build();
+                        case 14 -> SlotProviders.stack(Items.CHEST).named("Fill my inventory!").locked().build();
+                        case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                        case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
 
-            return switch (slotIndex) {
-                case 10 -> SlotProviders.stack(Items.PAPER).named("Buy only one!").locked().build();
-                case 12 -> SlotProviders.stack(Items.PAPER,64).named("Buy a stack!").locked().build();
-                case 14 -> SlotProviders.stack(Items.CHEST).named("Fill my inventory!").locked().build();
-                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
-                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
+        SlotProviders.registerDynamic(
+                "bazaar:sell_offer_amount",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_SELL_OFFER_AMOUNT_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-        SlotProviders.register("bazaar:sell_offer_amount", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+                    return switch (slotIndex) {
+                        case 10 -> SlotProviders.stack(Items.PAPER, 64).named("Sell a stack!").locked().build();
+                        case 12 -> SlotProviders.stack(Items.CHEST).named("Sell half your inventory!").locked().build();
+                        case 14 -> SlotProviders.stack(Items.CHEST).named("Sell whole inventory!").locked().build();
+                        case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                        case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
 
-            return switch (slotIndex) {
-                case 10 -> SlotProviders.stack(Items.PAPER,64).named("Sell a stack!").locked().build();
-                case 12 -> SlotProviders.stack(Items.CHEST).named("Sell half your inventory!").locked().build();
-                case 14 -> SlotProviders.stack(Items.CHEST).named("Sell whole inventory!").locked().build();
-                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
-                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
+        SlotProviders.registerDynamic(
+                "bazaar:sell_offer_price",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_SELL_OFFER_PRICE_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-        SlotProviders.register("bazaar:sell_offer_price", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+                    return switch (slotIndex) {
+                        case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Best Offer").locked().build();
+                        case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Best Offer -0.1").locked().build();
+                        case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("10% of Spread").locked().build();
+                        case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
+                        case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Sell Offer").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
 
-            return switch (slotIndex) {
-                case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Best Offer").locked().build();
-                case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Best Offer -0.1").locked().build();
-                case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("10% of Spread").locked().build();
-                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
-                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Sell Offer").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
-
-        SlotProviders.register("bazaar:sell_offer_confirmation", slotIndex -> {
+        SlotProviders.register("bazaar:sell_offer_confirmation", (slotIndex, selectedSlot) -> {
             if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
             return switch (slotIndex) {
@@ -115,7 +133,7 @@ public final class SlotRendererProvider {
             };
         });
 
-        SlotProviders.register("bazaar:instant_sell_amount", slotIndex -> {
+        SlotProviders.register("bazaar:instant_sell_amount", (slotIndex, selectedSlot) -> {
             if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
             return switch (slotIndex) {
@@ -127,15 +145,19 @@ public final class SlotRendererProvider {
             };
         });
 
-        SlotProviders.register("bazaar:flip_filled_buy_order", slotIndex -> {
-            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+        SlotProviders.registerDynamic(
+                "bazaar:flip_filled_buy_order",
+                () -> ButtonsConfig.HelpersConfig.HELPERS_FLIP_ORDER_PRICE_BUTTONS,
+                (slotIndex, selectedSlot) -> {
+                    if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
 
-            return switch (slotIndex) {
-                case 11 -> SlotProviders.stack(Items.RED_TERRACOTTA).named("Cancel Order").locked().build();
-                case 15 -> SlotProviders.stack(Items.NAME_TAG).named("Flip Order").locked().build();
-                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
-                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
-            };
-        });
+                    return switch (slotIndex) {
+                        case 11 -> SlotProviders.stack(Items.RED_TERRACOTTA).named("Cancel Order").locked().build();
+                        case 15 -> SlotProviders.stack(Items.NAME_TAG).named("Flip Order").locked().build();
+                        case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                        default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+                    };
+                }
+        );
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
@@ -1,0 +1,23 @@
+package com.github.mkram17.bazaarutils.config.util.client;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
+import net.minecraft.util.Identifier;
+
+public final class SlotRendererProvider {
+    private SlotRendererProvider() {}
+
+    public static void register() {
+        ResourcefulConfigUI.registerElementRenderer(
+                Identifier.of("bazaarutils", "slot"),
+                element -> {
+                    SlotElement se = SlotElement.wrap(element);
+                    return se != null ? new SlotRenderer(se) : null;
+                }
+        );
+
+        registerElementProviders();
+    }
+
+    private static void registerElementProviders() {}
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/SlotRendererProvider.java
@@ -1,7 +1,12 @@
 package com.github.mkram17.bazaarutils.config.util.client;
 
+import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
+import com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount.BuyOrderAmountHelper;
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigUI;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 
 public final class SlotRendererProvider {
@@ -19,5 +24,118 @@ public final class SlotRendererProvider {
         registerElementProviders();
     }
 
-    private static void registerElementProviders() {}
+    private static void registerElementProviders() {
+        SlotProviders.register("bazaar:buy_order_amount", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 10 -> SlotProviders.stack(Items.PAPER,64).named("Buy a stack!").locked().build();
+                case 12 -> SlotProviders.stack(Items.CHEST,2).named("Buy a big stack!").locked().build();
+                case 14 -> SlotProviders.stack(Items.CHEST,16).named("Buy a thousand!").locked().build();
+                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:buy_order_price", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Top Order").locked().build();
+                case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Top Order +0.1").locked().build();
+                case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("5% of Spread").locked().build();
+                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
+                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Buy Order").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:buy_order_confirmation", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 12 -> SlotProviders.stack(Items.PAPER).named("Buy Order").locked().build();
+                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Buy Order").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+
+        SlotProviders.register("bazaar:instant_buy_amount", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 10 -> SlotProviders.stack(Items.PAPER).named("Buy only one!").locked().build();
+                case 12 -> SlotProviders.stack(Items.PAPER,64).named("Buy a stack!").locked().build();
+                case 14 -> SlotProviders.stack(Items.CHEST).named("Fill my inventory!").locked().build();
+                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:sell_offer_amount", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 10 -> SlotProviders.stack(Items.PAPER,64).named("Sell a stack!").locked().build();
+                case 12 -> SlotProviders.stack(Items.CHEST).named("Sell half your inventory!").locked().build();
+                case 14 -> SlotProviders.stack(Items.CHEST).named("Sell whole inventory!").locked().build();
+                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Amount").locked().build();
+                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:sell_offer_price", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 10 -> SlotProviders.stack(Items.PAPER).named("Same as Best Offer").locked().build();
+                case 12 -> SlotProviders.stack(Items.GOLD_NUGGET).named("Best Offer -0.1").locked().build();
+                case 14 -> SlotProviders.stack(Items.GOLDEN_HORSE_ARMOR).named("10% of Spread").locked().build();
+                case 16 -> SlotProviders.stack(Items.OAK_SIGN).named("Custom Price").locked().build();
+                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Sell Offer").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:sell_offer_confirmation", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 12 -> SlotProviders.stack(Items.PAPER).named("Sell Offer").locked().build();
+                case 30 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                case 31 -> SlotProviders.stack(Items.BARRIER).named("Cancel Sell Offer").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:instant_sell_amount", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 11 -> SlotProviders.stack(Items.PAPER).named("Sell a stack!").locked().build();
+                case 13 -> SlotProviders.stack(Items.CHEST).named("Sell half your inventory!").locked().build();
+                case 15 -> SlotProviders.stack(Items.CHEST).named("Sell whole inventory!").locked().build();
+                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+
+        SlotProviders.register("bazaar:flip_filled_buy_order", slotIndex -> {
+            if (slotIndex < 0 || slotIndex > 35) return ItemStack.EMPTY;
+
+            return switch (slotIndex) {
+                case 11 -> SlotProviders.stack(Items.RED_TERRACOTTA).named("Cancel Order").locked().build();
+                case 15 -> SlotProviders.stack(Items.NAME_TAG).named("Flip Order").locked().build();
+                case 31 -> SlotProviders.stack(Items.ARROW).named("Go Back").locked().build();
+                default -> SlotProviders.stack(Items.GRAY_STAINED_GLASS_PANE).hideTooltip().build();
+            };
+        });
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/AbstractSelectorOverlay.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/AbstractSelectorOverlay.java
@@ -1,0 +1,39 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.screens.base.OverlayScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractSelectorOverlay extends OverlayScreen {
+    protected int ox, oy, ow, oh;
+
+    protected AbstractSelectorOverlay() {
+        super(MinecraftClient.getInstance().currentScreen);
+    }
+
+    protected boolean isOverOverlay(double mouseX, double mouseY) {
+        return mouseX >= ox && mouseX <= ox + ow && mouseY >= oy && mouseY <= oy + oh;
+    }
+
+    @Override
+    public void renderBackground(@NotNull DrawContext context, int mouseX, int mouseY, float delta) {
+        super.renderBackground(context, mouseX, mouseY, delta);
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.ACCENT, ox, oy, ow, oh);
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.BUTTON, ox + 1, oy + 1, ow - 2, oh - 2);
+    }
+
+    @Override
+    public boolean mouseClicked(Click click, boolean doubled) {
+        if (click.button() != 0 || isOverOverlay(click.x(), click.y())) {
+            return super.mouseClicked(click, doubled);
+        }
+
+        close();
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/ResetOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/ResetOptionWidget.java
@@ -1,0 +1,19 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.UIConstants;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.components.base.SpriteButton;
+import net.minecraft.client.gui.widget.ClickableWidget;
+
+public final class ResetOptionWidget {
+    private ResetOptionWidget() {}
+
+    public static ClickableWidget of(Runnable onPress) {
+        return SpriteButton.builder(12, 12)
+                .padding(2)
+                .sprite(ModSprites.RESET)
+                .tooltip(UIConstants.RESET)
+                .onPress(onPress)
+                .build();
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/SelectorOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/SelectorOptionWidget.java
@@ -1,0 +1,17 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options;
+
+import com.teamresourceful.resourcefulconfig.client.components.base.SpriteButton;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public abstract class SelectorOptionWidget extends SpriteButton implements ResetableWidget {
+    protected static final Text SELECT = Text.translatable("bazaarutils.rconfig.ui.constant.select");
+
+    protected SelectorOptionWidget(Identifier sprite, Text tooltip) {
+        super(12, 12, 2, sprite, () -> {}, tooltip);
+    }
+
+    @Override
+    public void reset() {}
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
 
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
 import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
@@ -41,22 +42,11 @@ public class ItemOptionWidget extends SelectorOptionWidget {
         this.setter = setter;
     }
 
-    private @Nullable Item resolveItem() {
-        Identifier id = Identifier.tryParse(getter.get());
-
-        if (id == null) return null;
-
-        return items.stream()
-                .filter(item -> Registries.ITEM.getId(item).equals(id))
-                .findFirst()
-                .orElse(null);
-    }
-
     @Override
     protected void drawIcon(DrawContext context, int mouseX, int mouseY, float delta) {
         super.drawIcon(context, mouseX, mouseY, delta);
 
-        Item item = resolveItem();
+        Item item = ResourcefulConfigItems.resolve(getter.get());
 
         if (item != null) {
             context.drawItem(new ItemStack(item), getX(), getY());

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemOptionWidget.java
@@ -1,0 +1,235 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ItemCell;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import com.teamresourceful.resourcefulconfig.client.components.options.text.TextBox;
+import com.teamresourceful.resourcefulconfig.client.utils.ListenableState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.input.AbstractInput;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ItemOptionWidget extends SelectorOptionWidget {
+    protected static final Text SEARCH = Text.translatable("bazaarutils.rconfig.ui.constant.search");
+
+    private final List<Item> items;
+    private final Supplier<String> getter;
+    private final Consumer<String> setter;
+
+    public ItemOptionWidget(List<Item> items, Supplier<String> getter, Consumer<String> setter) {
+        super(ModSprites.BUTTON, SELECT);
+        this.items = items;
+        this.getter = getter;
+        this.setter = setter;
+    }
+
+    private @Nullable Item resolveItem() {
+        Identifier id = Identifier.tryParse(getter.get());
+
+        if (id == null) return null;
+
+        return items.stream()
+                .filter(item -> Registries.ITEM.getId(item).equals(id))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    protected void drawIcon(DrawContext context, int mouseX, int mouseY, float delta) {
+        super.drawIcon(context, mouseX, mouseY, delta);
+
+        Item item = resolveItem();
+
+        if (item != null) {
+            context.drawItem(new ItemStack(item), getX(), getY());
+        }
+    }
+
+    @Override
+    public void onPress(@NotNull AbstractInput modifiers) {
+        MinecraftClient.getInstance().setScreen(new ItemSelector(this));
+    }
+
+    public static class ItemSelector extends AbstractSelectorOverlay {
+        private final ItemOptionWidget source;
+
+        private static final int PADDING = 4;
+        private static final int SPACING = 2;
+
+        private static final int GRID_COLS = 8;
+        private static final int MAX_ROWS = 5;
+
+        private static final int SEARCH_HEIGHT = 14;
+        private static final int OVERLAY_WIDTH = GRID_COLS * ContainerCell.CELL_SIZE + PADDING * 2;
+
+        private final Consumer<String> setter;
+
+        private final List<Item> allItems;
+        private List<Item> filteredItems;
+
+        private int scrollOffset = 0;
+
+        private final List<ClickableWidget> cellWidgets = new ArrayList<>();
+
+        private TextBox searchBox;
+
+        public ItemSelector(ItemOptionWidget source) {
+            this.source = source;
+            this.setter = source.setter;
+            this.allItems = source.items;
+            this.filteredItems = new ArrayList<>(allItems);
+        }
+
+        private int totalRows() {
+            return (int) Math.ceil(filteredItems.size() / (double) GRID_COLS);
+        }
+
+        private int maxScroll() {
+            return Math.max(0, totalRows() - MAX_ROWS);
+        }
+
+        private int visibleRows() {
+            return Math.min(MAX_ROWS, totalRows());
+        }
+
+        private int overlayHeight() {
+            return PADDING * 2 + SEARCH_HEIGHT + SPACING + MAX_ROWS * ContainerCell.CELL_SIZE;
+        }
+
+        private void rebuildCells() {
+            cellWidgets.forEach(this::remove);
+            cellWidgets.clear();
+
+            scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScroll());
+            oh = overlayHeight();
+
+            int startX = ox + PADDING;
+            int startY = oy + PADDING + SEARCH_HEIGHT + SPACING;
+            int startIndex = scrollOffset * GRID_COLS;
+
+            for (int i = 0; i < MAX_ROWS * GRID_COLS; i++) {
+                int itemIndex = startIndex + i;
+                if (itemIndex >= filteredItems.size()) break;
+
+                Item item = filteredItems.get(itemIndex);
+                int col = i % GRID_COLS;
+                int row = i / GRID_COLS;
+
+                ItemCell cell = new ItemCell(
+                        startX + col * ContainerCell.CELL_SIZE,
+                        startY + row * ContainerCell.CELL_SIZE,
+                        item,
+                        selected -> {
+                            this.setter.accept(Registries.ITEM.getId(selected).toString());
+                            close();
+                        }
+                );
+                cellWidgets.add(cell);
+                addDrawableChild(cell);
+            }
+        }
+
+        private void applySearch(String query) {
+            String q = query.toLowerCase().trim();
+            scrollOffset = 0;
+
+            filteredItems = allItems.stream().filter(item -> {
+                if (q.isEmpty()) return true;
+
+                String name = item.getName(new ItemStack(item)).getString().toLowerCase();
+                String key = Registries.ITEM.getId(item).toString().toLowerCase();
+
+                return name.contains(q) || key.contains(q);
+            }).toList();
+        }
+
+        @Override
+        protected void init() {
+            ow = OVERLAY_WIDTH;
+            oh = overlayHeight();
+
+            oy = (source.getY() + source.getHeight() + SPACING + oh <= this.height)
+                    ? source.getY() + source.getHeight() + SPACING
+                    : source.getY() - oh - SPACING;
+
+            int centerX = source.getX() + source.getWidth() / 2;
+            ox = MathHelper.clamp(centerX - ow / 2, 0, this.width - ow);
+
+            ListenableState<String> searchState = ListenableState.of("");
+            searchState.registerListener(q -> {
+                applySearch(q);
+                rebuildCells();
+            });
+
+            this.searchBox = new TextBox(ow - PADDING * 2, SEARCH_HEIGHT, searchState) {
+                @Override
+                public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+                    context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, ModSprites.BUTTON, getX(), getY(), getWidth(), getHeight());
+                    super.renderWidget(context, mouseX, mouseY, delta);
+                    this.applyCursor(context);
+                }
+            };
+            this.searchBox.setPosition(ox + PADDING, oy + PADDING);
+            this.searchBox.setPlaceholder(SEARCH.getString(), 0xFF808080);
+            addDrawableChild(this.searchBox);
+
+            rebuildCells();
+        }
+
+        @Override
+        public void renderBackground(@NotNull DrawContext context, int mouseX, int mouseY, float delta) {
+            super.renderBackground(context, mouseX, mouseY, delta);
+
+            if (maxScroll() > 0) {
+                int trackTop = oy + PADDING + SEARCH_HEIGHT + SPACING;
+                int trackHeight = visibleRows() * ContainerCell.CELL_SIZE;
+                int thumbHeight = Math.max(6, trackHeight * MAX_ROWS / totalRows());
+                int thumbTop = trackTop + (trackHeight - thumbHeight) * scrollOffset / Math.max(1, maxScroll());
+                context.fill(ox + ow - 3, trackTop, ox + ow - 1, trackTop + trackHeight, 0x44FFFFFF);
+                context.fill(ox + ow - 3, thumbTop, ox + ow - 1, thumbTop + thumbHeight, 0xAAFFFFFF);
+            }
+        }
+
+        @Override
+        public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+            if (!isOverOverlay(mouseX, mouseY)) return false;
+
+            int newOffset = MathHelper.clamp(scrollOffset - (int) Math.signum(scrollY), 0, maxScroll());
+
+            if (newOffset != scrollOffset) {
+                scrollOffset = newOffset;
+                rebuildCells();
+            }
+
+            return true;
+        }
+
+        @Override
+        public boolean charTyped(CharInput input) {
+            if (searchBox != null && !searchBox.isFocused()) {
+                setInitialFocus(searchBox);
+                return searchBox.charTyped(input);
+            }
+
+            return super.charTyped(input);
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
@@ -22,14 +22,7 @@ public class ItemStringOptionWidget extends StringOptionWidget implements Reseta
     @Override
     public void updateIfFocused() {
         if (!isFocused()) {
-            Identifier id = Identifier.tryParse(getter.get());
-
-            Item resolved = id != null
-                    ? ResourcefulConfigItems.getItems().stream()
-                    .filter(item -> Registries.ITEM.getId(item).equals(id))
-                    .findFirst()
-                    .orElse(null)
-                    : null;
+            Item resolved = ResourcefulConfigItems.resolve(getter.get());
 
             setValue(resolved != null ? resolved.getName(new ItemStack(resolved)).getString() : getter.get());
             setCursorPosition(0);

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/ItemStringOptionWidget.java
@@ -1,0 +1,58 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.StringOptionWidget;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class ItemStringOptionWidget extends StringOptionWidget implements ResetableWidget {
+    private final Supplier<String> getter;
+
+    public ItemStringOptionWidget(Supplier<String> getter, Function<String, Boolean> setter) {
+        super(getter, setter, false);
+        this.getter = getter;
+    }
+
+    @Override
+    public void updateIfFocused() {
+        if (!isFocused()) {
+            Identifier id = Identifier.tryParse(getter.get());
+
+            Item resolved = id != null
+                    ? ResourcefulConfigItems.getItems().stream()
+                    .filter(item -> Registries.ITEM.getId(item).equals(id))
+                    .findFirst()
+                    .orElse(null)
+                    : null;
+
+            setValue(resolved != null ? resolved.getName(new ItemStack(resolved)).getString() : getter.get());
+            setCursorPosition(0);
+            setHighlightPos(0);
+            setTextColor(0xFFE0E0E0);
+        }
+    }
+
+    @Override
+    public void setFocused(boolean focused) {
+        boolean wasFocused = isFocused();
+
+        super.setFocused(focused);
+
+        if (focused && !wasFocused) {
+            setValue(getter.get());
+            setCursorPosition(getValue().length());
+            setHighlightPos(getValue().length());
+        }
+    }
+
+    @Override
+    public void reset() {
+        setValue(getter.get());
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
@@ -1,0 +1,35 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.NumberOptionWidget;
+import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+
+public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implements ResetableWidget {
+    private final int maxSlot;
+
+    public SlotNumberOptionWidget(SlotElement element) {
+        super(
+                element.valueEntry()::getInt,
+                value -> {
+                    element.valueEntry().setInt(value);
+                    return true;
+                },
+                s -> {
+                    int value = Integer.parseInt(s);
+                    int max   = element.totalSlots() - 1;
+                    if (value < 0 || value > max) throw new NumberFormatException();
+                    return value;
+                },
+                NumberOptionWidget.INTEGER_FILTER
+        );
+        this.maxSlot = element.totalSlots() - 1;
+    }
+
+    private static final boolean canExpand = false;
+
+    @Override
+    public void updateIfFocused() {
+        // if (!canExpand) return;
+        // rather than to do an unless check, we just no-op, as it should never expand.
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotNumberOptionWidget.java
@@ -1,8 +1,10 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
 
 import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.teamresourceful.resourcefulconfig.client.components.options.types.NumberOptionWidget;
 import com.teamresourceful.resourcefulconfig.client.components.options.types.ResetableWidget;
+import net.minecraft.item.ItemStack;
 
 public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implements ResetableWidget {
     private final int maxSlot;
@@ -18,6 +20,13 @@ public class SlotNumberOptionWidget extends NumberOptionWidget<Integer> implemen
                     int value = Integer.parseInt(s);
                     int max   = element.totalSlots() - 1;
                     if (value < 0 || value > max) throw new NumberFormatException();
+                    ItemStack stack = element.provider().getStack(value);
+                    // Known undeseriable/bug behavior:
+                    // to throw NumberFormatException() will cause the input box to fallback to the last typed-in value,
+                    // not the last saved/valid value. This is a implementation detail of NumberOptionWidget,
+                    // and although we may override and fix it with a custom setChangedListener(...) call,
+                    // it'd be better off if upstream fixes this behavior. 
+                    if (!stack.isEmpty() && stack.contains(CustomDataComponents.SLOT_SELECTOR_LOCKED)) throw new NumberFormatException();
                     return value;
                 },
                 NumberOptionWidget.INTEGER_FILTER

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
@@ -1,0 +1,103 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types;
+
+import com.github.mkram17.bazaarutils.config.util.api.SlotElement;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.AbstractSelectorOverlay;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.SelectorOptionWidget;
+import com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector.ContainerCell;
+import com.teamresourceful.resourcefulconfig.client.UIConstants;
+import com.teamresourceful.resourcefulconfig.client.components.ModSprites;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class SlotOptionWidget extends SelectorOptionWidget {
+    private static final int SIZE = 12;
+
+    private final SlotElement element;
+    private final Supplier<Integer> getter;
+    private final Consumer<Integer> setter;
+
+    public SlotOptionWidget(SlotElement element, Supplier<Integer> getter, Consumer<Integer> setter) {
+        super(ModSprites.EDIT, UIConstants.EDIT);
+        this.element = element;
+        this.getter = getter;
+        this.setter = setter;
+    }
+
+    @Override
+    public void onPress(@NotNull net.minecraft.client.input.AbstractInput modifiers) {
+        MinecraftClient.getInstance().setScreen(new SlotSelector(this, element, getter.get(), setter));
+    }
+
+    public static class SlotSelector extends AbstractSelectorOverlay {
+        private final SlotOptionWidget source;
+
+        private static final int PADDING = 4;
+        private static final int SPACING = 2;
+
+        private final SlotElement element;
+
+        private final Consumer<Integer> setter;
+
+        private int selectedSlot;
+
+        private final List<ClickableWidget> cellWidgets = new ArrayList<>();
+
+        public SlotSelector(SlotOptionWidget source, SlotElement element, int currentSlot, Consumer<Integer> setter) {
+            this.source = source;
+            this.element = element;
+            this.setter = setter;
+            this.selectedSlot = currentSlot;
+        }
+
+        private void rebuildCells() {
+            cellWidgets.forEach(this::remove);
+            cellWidgets.clear();
+
+            int startX = ox + PADDING;
+            int startY = oy + PADDING;
+
+            for (int slot = 0; slot < element.totalSlots(); slot++) {
+                final int s = slot;
+                int col = slot % element.cols();
+                int row = slot / element.cols();
+                ItemStack stack = element.provider().getStack(slot);
+
+                ContainerCell cell = new ContainerCell(
+                        startX + col * ContainerCell.CELL_SIZE,
+                        startY + row * ContainerCell.CELL_SIZE,
+                        stack,
+                        slot == selectedSlot,
+                        () -> {
+                            setter.accept(s);
+                            close();
+                        }
+                );
+                cellWidgets.add(cell);
+                addDrawableChild(cell);
+            }
+        }
+
+        @Override
+        protected void init() {
+            ow = PADDING * 2 + element.cols() * ContainerCell.CELL_SIZE;
+            oh = PADDING * 2 + element.rows() * ContainerCell.CELL_SIZE;
+
+            oy = (source.getY() + source.getHeight() + SPACING + oh <= this.height)
+                    ? source.getY() + source.getHeight() + SPACING
+                    : source.getY() - oh - SPACING;
+
+            int centerX = source.getX() + source.getWidth() / 2;
+            ox = MathHelper.clamp(centerX - ow / 2, 0, this.width - ow);
+
+            rebuildCells();
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/SlotOptionWidget.java
@@ -46,7 +46,7 @@ public class SlotOptionWidget extends SelectorOptionWidget {
 
         private final Consumer<Integer> setter;
 
-        private int selectedSlot;
+        private final int selectedSlot;
 
         private final List<ClickableWidget> cellWidgets = new ArrayList<>();
 
@@ -68,7 +68,7 @@ public class SlotOptionWidget extends SelectorOptionWidget {
                 final int s = slot;
                 int col = slot % element.cols();
                 int row = slot / element.cols();
-                ItemStack stack = element.provider().getStack(slot);
+                ItemStack stack = element.provider().getStack(slot, selectedSlot);
 
                 ContainerCell cell = new ContainerCell(
                         startX + col * ContainerCell.CELL_SIZE,

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
 
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.teamresourceful.resourcefulconfig.client.components.base.BaseWidget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.RenderPipelines;
@@ -28,6 +29,7 @@ public class ContainerCell extends BaseWidget {
         setPosition(x, y);
         this.stack    = stack;
         this.selected = selected;
+        this.active   = !(!stack.isEmpty() && stack.contains(CustomDataComponents.SLOT_SELECTOR_LOCKED));
         this.onSelect = onSelect;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ContainerCell.java
@@ -1,0 +1,63 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
+
+import com.teamresourceful.resourcefulconfig.client.components.base.BaseWidget;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.tooltip.TooltipType;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class ContainerCell extends BaseWidget {
+    public static final int CELL_SIZE = 18;
+    private static final Identifier SLOT_SPRITE = Identifier.ofVanilla("container/slot");
+
+    private final ItemStack stack;
+
+    private final boolean selected;
+
+    private final Runnable onSelect;
+
+    public ContainerCell(int x, int y, ItemStack stack, boolean selected, Runnable onSelect) {
+        super(CELL_SIZE, CELL_SIZE);
+        setPosition(x, y);
+        this.stack    = stack;
+        this.selected = selected;
+        this.onSelect = onSelect;
+    }
+
+    @Override
+    protected void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SLOT_SPRITE, getX(), getY(), CELL_SIZE, CELL_SIZE);
+
+        if (selected) {
+            context.fill(getX() + 1, getY() + 1, getX() + CELL_SIZE - 1, getY() + CELL_SIZE - 1, 0x8800AA00);
+        } else if (isHovered()) {
+            context.fill(getX() + 1, getY() + 1, getX() + CELL_SIZE - 1, getY() + CELL_SIZE - 1, 0x80FFFFFF);
+        }
+
+        if (!stack.isEmpty()) {
+            context.drawItem(stack, getX() + 1, getY() + 1);
+
+            if (isHovered() && !stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT).hideTooltip()) {
+                context.drawTooltip(
+                        MinecraftClient.getInstance().textRenderer,
+                        stack.getTooltip(Item.TooltipContext.DEFAULT, null, TooltipType.BASIC),
+                        mouseX, mouseY
+                );
+            }
+        }
+
+        this.applyCursor(context);
+    }
+
+    @Override
+    public void onClick(@NotNull Click event, boolean doubled) {
+        onSelect.run();
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ItemCell.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/config/util/client/components/options/types/selector/ItemCell.java
@@ -1,0 +1,12 @@
+package com.github.mkram17.bazaarutils.config.util.client.components.options.types.selector;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+import java.util.function.Consumer;
+
+public class ItemCell extends ContainerCell {
+    public ItemCell(int x, int y, Item item, Consumer<Item> onSelect) {
+        super(x, y, new ItemStack(item), false, () -> onSelect.accept(item));
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
@@ -12,8 +12,8 @@ import net.minecraft.item.Items;
 @ConfigObject
 public class CancelOrderAndSearch extends BUListener implements ItemButton {
     @Override
-    public int getSlotNumber() {
-        return ButtonsConfig.CANCEL_ORDER_AND_SEARCH.slotNumber;
+    public int getSlotIndex() {
+        return ButtonsConfig.CANCEL_ORDER_AND_SEARCH.slotIndex;
     }
 
     @Getter

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
@@ -4,6 +4,7 @@ import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.events.listener.BUListener;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderInfo;
 import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import lombok.Getter;
 import net.minecraft.item.ItemStack;
@@ -14,6 +15,11 @@ public class CancelOrderAndSearch extends BUListener implements ItemButton {
     @Override
     public int getSlotIndex() {
         return ButtonsConfig.CANCEL_ORDER_AND_SEARCH.slotIndex;
+    }
+
+    @Override
+    public ItemRef getItemRef() {
+        return ItemRef.of(Items.BLUE_TERRACOTTA);
     }
 
     @Getter

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/CancelOrderAndSearch.java
@@ -3,7 +3,7 @@ package com.github.mkram17.bazaarutils.features.gui.buttons;
 import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.events.listener.BUListener;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.OrderInfo;
-import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import lombok.Getter;

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/BookmarkSearchWidget.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/BookmarkSearchWidget.java
@@ -10,7 +10,7 @@ import com.github.mkram17.bazaarutils.utils.annotations.autoregistration.Registe
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
-import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.PlayerSlots;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.container.ContainerManager;

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/ToggleBookmarkButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/ToggleBookmarkButton.java
@@ -1,6 +1,7 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.bookmarks;
 
 import com.github.mkram17.bazaarutils.BazaarUtils;
+import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.events.ReplaceItemEvent;
 import com.github.mkram17.bazaarutils.events.SlotClickEvent;
 import com.github.mkram17.bazaarutils.events.listener.BUListener;
@@ -12,6 +13,8 @@ import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.ItemInfo;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemGroups;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import lombok.Getter;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.component.DataComponentTypes;
@@ -24,8 +27,15 @@ import java.util.Optional;
 
 @Module
 public class ToggleBookmarkButton extends BUListener implements ItemButton {
-    @Getter
-    private transient ItemStack replacementItem;
+    @Override
+    public int getSlotIndex() {
+        return 0;
+    }
+
+    @Override
+    public ItemRef getItemRef() {
+        return ItemRef.of(BookmarkUtil.currentBookmarkOpt::isEmpty, ItemGroups.BOOKMARKED_STATE_GROUP);
+    }
 
     private boolean inCorrectScreen() {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.ITEM_PAGE);
@@ -39,44 +49,35 @@ public class ToggleBookmarkButton extends BUListener implements ItemButton {
                 .flatMap(BazaarScreenHandler::getDisplayItemName);
     }
 
-    private void buildReplacementItem(String itemName) {
+    @Override
+    public ItemStack getReplacementItem(int size) {
         boolean bookmarked = BookmarkUtil.currentBookmarkOpt.isPresent();
 
-        this.replacementItem = new ItemStack(
-                bookmarked ? Items.RED_STAINED_GLASS_PANE : Items.GREEN_STAINED_GLASS_PANE
-        );
+        ItemStack stack = ItemButton.super.getReplacementItem(size);
 
-        replacementItem.set(
+        stack.set(
                 DataComponentTypes.CUSTOM_NAME,
                 Text.literal(bookmarked
-                        ? "Remove " + BookmarkUtil.getCurrentBookmarkOpt().get().name() + " Bookmark"
-                        : "Bookmark " + itemName)
-        );
+                        ? "Remove " + BookmarkUtil.currentBookmarkOpt.get().name() + " Bookmark"
+                        : "Bookmark " + resolveCurrentItemName().orElse("?")));
 
-        replacementItem.set(
-                CustomDataComponents.CUSTOM_SIZE,
-                bookmarked ? "⃠ " : "★"
-        );
+        stack.set(CustomDataComponents.CUSTOM_SIZE, bookmarked ? "⃠ " : "★");
+
+        return stack;
     }
 
     @EventHandler
     private void onReplaceItemEvent(ReplaceItemEvent event) {
-        if (!shouldReplaceItem(event) || !ScreenManager.getInstance().isCurrent(BazaarScreens.ITEM_PAGE)) {
-            return;
-        }
+        if (!shouldReplaceItem(event) || !inCorrectScreen()) return;
 
-        resolveCurrentItemName().ifPresent(name -> {
-            BookmarkUtil.currentBookmarkOpt = BookmarkUtil.findMatchingBookmark(name);
-            buildReplacementItem(name);
-            event.setReplacement(replacementItem);
-        });
+        resolveCurrentItemName().ifPresent(name -> BookmarkUtil.currentBookmarkOpt = BookmarkUtil.findMatchingBookmark(name));
+
+        event.setReplacement(getReplacementItem());
     }
 
     @EventHandler
     private void onClick(SlotClickEvent event) {
-        if (!wasButtonSlotClicked(event) || !ScreenManager.getInstance().isCurrent(BazaarScreens.ITEM_PAGE)) {
-            return;
-        }
+        if (!wasButtonClicked(event) || !inCorrectScreen()) return;
 
         SoundUtil.playSound(BUTTON_SOUND, BUTTON_VOLUME);
 
@@ -105,13 +106,6 @@ public class ToggleBookmarkButton extends BUListener implements ItemButton {
             BookmarkUtil.currentBookmarkOpt = Optional.of(newBookmark);
         }
 
-        buildReplacementItem(name);
-
         BookmarkUtil.saveBookmarks();
-    }
-
-    @Override
-    public int getSlotNumber() {
-        return 0;
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/ToggleBookmarkButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/bookmarks/ToggleBookmarkButton.java
@@ -1,7 +1,5 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.bookmarks;
 
-import com.github.mkram17.bazaarutils.BazaarUtils;
-import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
 import com.github.mkram17.bazaarutils.events.ReplaceItemEvent;
 import com.github.mkram17.bazaarutils.events.SlotClickEvent;
 import com.github.mkram17.bazaarutils.events.listener.BUListener;
@@ -9,13 +7,12 @@ import com.github.mkram17.bazaarutils.utils.SoundUtil;
 import com.github.mkram17.bazaarutils.utils.annotations.modules.Module;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreenHandler;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
-import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.ItemInfo;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
-import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemGroups;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.groups.ItemGroups;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
-import lombok.Getter;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -1,9 +1,11 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
@@ -14,6 +16,8 @@ import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -84,6 +88,10 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount impl
         this.slotIndex = slotIndex;
     }
 
+    public BuyOrderAmountHelper() {
+        this(getNextSlotIndex());
+    }
+
     @Override
     protected int computeFixedValue(TransactionState state) {
         return getFixedAmount();
@@ -107,4 +115,11 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount impl
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:buy_order_amount").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -11,12 +11,13 @@ import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
+public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -92,4 +93,18 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Order " + getButtonItemStackSize(state) + " items.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (amountStrategy) {
+            case AmountStrategy.MAX -> "Orders MAX possible items";
+            case AmountStrategy.FIXED -> "Orders " + fixedAmount + " items";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -71,10 +71,6 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     public Item getButtonItem() {
         return Items.GREEN_STAINED_GLASS_PANE;
     }
-
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -18,16 +18,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -88,9 +78,8 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.BUY_ORDER_AMOUNT);
     }
 
-    public BuyOrderAmountHelper(boolean enabled, int slotIndex) {
+    public BuyOrderAmountHelper(int slotIndex) {
         super("Buy Order Amount Helper", BazaarSlots.BUY_ORDER.INPUT_CUSTOM_AMOUNT.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -30,6 +30,17 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     public boolean enabled;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -30,15 +30,15 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     public boolean enabled;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
-            value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            value = "The container slot where the button will be placed.",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "amount_strategy",
@@ -82,10 +82,10 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.BUY_ORDER_AMOUNT);
     }
 
-    public BuyOrderAmountHelper(boolean enabled, int slotNumber) {
+    public BuyOrderAmountHelper(boolean enabled, int slotIndex) {
         super("Buy Order Amount Helper", BazaarSlots.BUY_ORDER.INPUT_CUSTOM_AMOUNT.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -1,24 +1,22 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
 public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
-
     @ConfigEntry(
             id = "enabled",
             translation = "bazaarutils.config.buttons.button.container.enabled.label"
@@ -79,9 +77,8 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.BUY, TransactionType.Method.ORDER);
 
     @Override
-    public Item getButtonItem() {
-        return Items.GREEN_STAINED_GLASS_PANE;
-    }
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/BuyOrderAmountHelper.java
@@ -46,7 +46,9 @@ public class BuyOrderAmountHelper extends SignInputHelper.TransactionAmount {
             value = "The container slot where the button will be placed.",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:buy_order_amount")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -1,24 +1,22 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
 public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
-
     @ConfigEntry(
             id = "enabled",
             translation = "bazaarutils.config.buttons.button.container.enabled.label"
@@ -79,10 +77,8 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.BUY, TransactionType.Method.INSTANT);
 
     @Override
-    public Item getButtonItem() {
-        return Items.GREEN_STAINED_GLASS_PANE;
-    }
-
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -27,18 +27,18 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
             value = "Whether the button will be registered or not",
             translation = "bazaarutils.config.buttons.button.container.enabled.hint"
     )
-    public boolean enabled;
+    public boolean enabled = false;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
-            value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            value = "The container slot where the button will be placed.",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "amount_strategy",
@@ -82,10 +82,10 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.INSTANT_BUY);
     }
 
-    public InstantBuyAmountHelper(boolean enabled, int slotNumber) {
+    public InstantBuyAmountHelper(boolean enabled, int slotIndex) {
         super("Instant Buy Amount Helper", BazaarSlots.INSTANT_BUY.INPUT_CUSTOM_AMOUNT.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -30,6 +30,17 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
     public boolean enabled = false;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -1,10 +1,12 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
@@ -14,6 +16,8 @@ import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -84,6 +88,10 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount im
         this.slotIndex = slotIndex;
     }
 
+    public InstantBuyAmountHelper() {
+        this(getNextSlotIndex());
+    }
+
     @Override
     protected int computeFixedValue(TransactionState state) {
         return getFixedAmount();
@@ -107,4 +115,11 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount im
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:instant_buy_amount").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -46,7 +46,9 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
             value = "The container slot where the button will be placed.",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:instant_buy_amount")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -72,9 +72,6 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
         return Items.GREEN_STAINED_GLASS_PANE;
     }
 
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -18,16 +18,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled = false;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -88,9 +78,8 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.INSTANT_BUY);
     }
 
-    public InstantBuyAmountHelper(boolean enabled, int slotIndex) {
+    public InstantBuyAmountHelper(int slotIndex) {
         super("Instant Buy Amount Helper", BazaarSlots.INSTANT_BUY.INPUT_CUSTOM_AMOUNT.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/InstantBuyAmountHelper.java
@@ -11,12 +11,13 @@ import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
+public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -92,4 +93,18 @@ public class InstantBuyAmountHelper extends SignInputHelper.TransactionAmount {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Offer " + getButtonItemStackSize(state) + " items.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (amountStrategy) {
+            case MAX -> "Buys MAX possible items";
+            case FIXED -> "Buys " + fixedAmount + " items";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -1,9 +1,11 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
@@ -14,6 +16,8 @@ import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -84,6 +88,10 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount imp
         this.slotIndex = slotIndex;
     }
 
+    public SellOfferAmountHelper() {
+        this(getNextSlotIndex());
+    }
+
     @Override
     protected int computeFixedValue(TransactionState state) {
         return getFixedAmount();
@@ -107,4 +115,11 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount imp
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:sell_offer_amount").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -46,7 +46,9 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
             value = "The container slot where the button will be registered at",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:sell_offer_amount")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -1,24 +1,22 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.amount;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
 public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
-
     @ConfigEntry(
             id = "enabled",
             translation = "bazaarutils.config.buttons.button.container.enabled.label"
@@ -79,10 +77,8 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.SELL, TransactionType.Method.ORDER);
 
     @Override
-    public Item getButtonItem() {
-        return Items.GREEN_STAINED_GLASS_PANE;
-    }
-
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -72,9 +72,6 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
         return Items.GREEN_STAINED_GLASS_PANE;
     }
 
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -30,6 +30,17 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
     public boolean enabled;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -30,15 +30,15 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
     public boolean enabled;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
             value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "amount_strategy",
@@ -82,10 +82,10 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.SELL_ORDER_AMOUNT);
     }
 
-    public SellOfferAmountHelper(boolean enabled, int slotNumber) {
+    public SellOfferAmountHelper(boolean enabled, int slotIndex) {
         super("Sell Offer Amount Helper", BazaarSlots.SELL_OFFER.INPUT_CUSTOM_AMOUNT.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -11,12 +11,13 @@ import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
+public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -92,4 +93,18 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Offer " + getButtonItemStackSize(state) + " items.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (amountStrategy) {
+            case MAX -> "Offers the whole of your inventory";
+            case FIXED -> "Offers " + fixedAmount + " items";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/amount/SellOfferAmountHelper.java
@@ -18,16 +18,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -88,9 +78,8 @@ public class SellOfferAmountHelper extends SignInputHelper.TransactionAmount {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.SELL_ORDER_AMOUNT);
     }
 
-    public SellOfferAmountHelper(boolean enabled, int slotIndex) {
+    public SellOfferAmountHelper(int slotIndex) {
         super("Sell Offer Amount Helper", BazaarSlots.SELL_OFFER.INPUT_CUSTOM_AMOUNT.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -19,16 +19,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -80,9 +70,8 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.BUY_ORDER_PRICE);
     }
 
-    public BuyOrderPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
+    public BuyOrderPriceHelper(int slotIndex, PricingPosition pricingPosition) {
         super("Buy Order Price Helper", BazaarSlots.BUY_ORDER.INPUT_CUSTOM_PRICE.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -47,7 +47,9 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
             value = "The container slot where the button will be registered at",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:buy_order_price")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -1,19 +1,18 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
@@ -70,13 +69,8 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.BUY, TransactionType.Method.ORDER);
 
     @Override
-    public Item getButtonItem() {
-        return switch (getPricingPosition()) {
-            case COMPETITIVE -> Items.GREEN_STAINED_GLASS_PANE;
-            case MATCHED -> Items.YELLOW_STAINED_GLASS_PANE;
-            case OUTBID -> Items.ORANGE_STAINED_GLASS_PANE;
-        };
-    }
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -30,6 +30,17 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
     public boolean enabled;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -17,7 +17,7 @@ import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
+public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -80,4 +80,19 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Bid " + getButtonItemStackSize(state) + " per item.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (pricingPosition) {
+            case COMPETITIVE -> "Bids +0.1 above best offer";
+            case MATCHED -> "Bids equal to best offer";
+            case OUTBID -> "Bids -0.1 below best offer";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -1,19 +1,24 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -76,6 +81,10 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost impleme
         this.pricingPosition = pricingPosition;
     }
 
+    public BuyOrderPriceHelper() {
+        this(getNextSlotIndex(), PricingPosition.COMPETITIVE);
+    }
+
     @Override
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Bid " + getButtonItemStackSize(state) + " per item.");
@@ -95,4 +104,11 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost impleme
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:buy_order_price").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -30,15 +30,15 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
     public boolean enabled;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
             value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "pricing_position",
@@ -77,10 +77,10 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.BUY_ORDER_PRICE);
     }
 
-    public BuyOrderPriceHelper(boolean enabled, int slotNumber, PricingPosition pricingPosition) {
+    public BuyOrderPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
         super("Buy Order Price Helper", BazaarSlots.BUY_ORDER.INPUT_CUSTOM_PRICE.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/BuyOrderPriceHelper.java
@@ -66,10 +66,6 @@ public class BuyOrderPriceHelper extends SignInputHelper.TransactionCost {
             case OUTBID -> Items.ORANGE_STAINED_GLASS_PANE;
         };
     }
-
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -6,14 +6,12 @@ import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
@@ -70,14 +68,8 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.SELL, TransactionType.Method.ORDER);
 
     @Override
-    public Item getButtonItem() {
-        return switch (getPricingPosition()) {
-            case COMPETITIVE -> Items.GREEN_STAINED_GLASS_PANE;
-            case MATCHED -> Items.YELLOW_STAINED_GLASS_PANE;
-            case OUTBID -> Items.ORANGE_STAINED_GLASS_PANE;
-        };
-    }
-
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -30,15 +30,15 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
     public boolean enabled;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
             value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "pricing_position",
@@ -77,10 +77,10 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.COMPLETED_BUY_ORDER_OPTIONS);
     }
 
-    public FlipOrderPriceHelper(boolean enabled, int slotNumber, PricingPosition pricingPosition) {
+    public FlipOrderPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
         super("Flip Order Price Helper", BazaarSlots.ORDER_OPTIONS.FLIP_FILLED_BUY_ORDER.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -12,12 +12,13 @@ import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
+public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -80,4 +81,19 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Ask " + getButtonItemStackSize(state) + " per item.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (pricingPosition) {
+            case COMPETITIVE -> "Flips asking +0.1 above best bid";
+            case MATCHED -> "Flips asking equal to best bid";
+            case OUTBID -> "Flips asking -0.1 below best bid";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -19,16 +19,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -80,9 +70,8 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.COMPLETED_BUY_ORDER_OPTIONS);
     }
 
-    public FlipOrderPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
+    public FlipOrderPriceHelper(int slotIndex, PricingPosition pricingPosition) {
         super("Flip Order Price Helper", BazaarSlots.ORDER_OPTIONS.FLIP_FILLED_BUY_ORDER.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -1,11 +1,13 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
@@ -15,6 +17,8 @@ import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -77,6 +81,10 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip implem
         this.pricingPosition = pricingPosition;
     }
 
+    public FlipOrderPriceHelper() {
+        this(getNextSlotIndex(), PricingPosition.COMPETITIVE);
+    }
+
     @Override
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Ask " + getButtonItemStackSize(state) + " per item.");
@@ -96,4 +104,11 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip implem
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:flip_filled_buy_order").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -67,9 +67,6 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
         };
     }
 
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
@@ -46,7 +47,9 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
             value = "The container slot where the button will be registered at",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:flip_filled_buy_order")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/FlipOrderPriceHelper.java
@@ -30,6 +30,17 @@ public class FlipOrderPriceHelper extends SignInputHelper.TransactionFlip {
     public boolean enabled;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -67,9 +67,6 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
         };
     }
 
-    @Override
-    public ItemStack getReplacementItem() {
-        return new ItemStack(this::getButtonItem, 1);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -1,11 +1,14 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.features.gui.ButtonsConfig;
+import com.github.mkram17.bazaarutils.config.util.api.SlotProviders;
 import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
 import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
@@ -15,6 +18,8 @@ import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
+
+import java.util.stream.IntStream;
 
 @Getter
 @ConfigObject
@@ -77,6 +82,10 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost implem
         this.pricingPosition = pricingPosition;
     }
 
+    public SellOfferPriceHelper() {
+        this(getNextSlotIndex(), PricingPosition.COMPETITIVE);
+    }
+
     @Override
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Ask " + getButtonItemStackSize(state) + " per item.");
@@ -96,4 +105,11 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost implem
         return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
     }
 
+    private static int getNextSlotIndex() {
+        return IntStream.rangeClosed(0, 35)
+                .filter(i -> !SlotProviders.get("bazaar:sell_offer_price").getStack(i)
+                        .getOrDefault(CustomDataComponents.SLOT_SELECTOR_LOCKED, false))
+                .findFirst()
+                .orElse(35);
+    }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -12,12 +12,13 @@ import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
+import com.teamresourceful.resourcefulconfig.api.types.info.ListEntryInfoProvider;
 import lombok.Getter;
 import net.minecraft.text.Text;
 
 @Getter
 @ConfigObject
-public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
+public class SellOfferPriceHelper extends SignInputHelper.TransactionCost implements ListEntryInfoProvider {
     @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
@@ -80,4 +81,19 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
     protected Text getButtonItemText(TransactionState state) {
         return Text.of("Ask " + getButtonItemStackSize(state) + " per item.");
     }
+
+    @Override
+    public Text getTitle(int index) {
+        return Text.literal(switch (pricingPosition) {
+            case COMPETITIVE -> "Asks +0.1 above best bid";
+            case MATCHED -> "Asks equal to best bid";
+            case OUTBID -> "Asks -0.1 below best bid";
+        });
+    }
+
+    @Override
+    public Text getDescription(int index) {
+        return Text.literal("Slot " + slotIndex + " · " + resolveItem().getName().getString());
+    }
+
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -19,16 +19,6 @@ import net.minecraft.text.Text;
 @ConfigObject
 public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
     @ConfigEntry(
-            id = "enabled",
-            translation = "bazaarutils.config.buttons.button.container.enabled.label"
-    )
-    @Comment(
-            value = "Whether the button will be registered or not",
-            translation = "bazaarutils.config.buttons.button.container.enabled.hint"
-    )
-    public boolean enabled;
-
-    @ConfigEntry(
             id = "item_id",
             translation = "bazaarutils.config.buttons.button.container.item_id.label"
     )
@@ -80,9 +70,8 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.SELL_ORDER_PRICE);
     }
 
-    public SellOfferPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
+    public SellOfferPriceHelper(int slotIndex, PricingPosition pricingPosition) {
         super("Sell Offer Price Helper", BazaarSlots.SELL_OFFER.INPUT_CUSTOM_PRICE.slot);
-        this.enabled = enabled;
         this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -30,15 +30,15 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
     public boolean enabled;
 
     @ConfigEntry(
-            id = "slot_number",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.label"
+            id = "slot_index",
+            translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )
     @Comment(
             value = "The container slot where the button will be registered at",
-            translation = "bazaarutils.config.buttons.button.container.slot_number.hint"
+            translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
     @ConfigOption.Range(min = 0, max = 35)
-    public int slotNumber;
+    public int slotIndex;
 
     @ConfigEntry(
             id = "pricing_position",
@@ -77,10 +77,10 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
         return ScreenManager.getInstance().isCurrent(BazaarScreens.SELL_ORDER_PRICE);
     }
 
-    public SellOfferPriceHelper(boolean enabled, int slotNumber, PricingPosition pricingPosition) {
+    public SellOfferPriceHelper(boolean enabled, int slotIndex, PricingPosition pricingPosition) {
         super("Sell Offer Price Helper", BazaarSlots.SELL_OFFER.INPUT_CUSTOM_PRICE.slot);
         this.enabled = enabled;
-        this.slotNumber = slotNumber;
+        this.slotIndex = slotIndex;
         this.pricingPosition = pricingPosition;
     }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.features.gui.buttons.inputhelper.price;
 
+import com.github.mkram17.bazaarutils.config.util.api.annotations.ContainerSlot;
 import com.github.mkram17.bazaarutils.utils.bazaar.SignInputHelper;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarScreens;
 import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
@@ -46,7 +47,9 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
             value = "The container slot where the button will be registered at",
             translation = "bazaarutils.config.buttons.button.container.slot_index.hint"
     )
+    @ContainerSlot(rows = 4, cols = 9, provider = "bazaar:sell_offer_price")
     @ConfigOption.Range(min = 0, max = 35)
+    @ConfigOption.Renderer("bazaarutils:slot")
     public int slotIndex;
 
     @ConfigEntry(

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -30,6 +30,17 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
     public boolean enabled;
 
     @ConfigEntry(
+            id = "item_id",
+            translation = "bazaarutils.config.buttons.button.container.item_id.label"
+    )
+    @Comment(
+            value = "The item that will be placed as the button.",
+            translation = "bazaarutils.config.buttons.button.container.item_id.hint"
+    )
+    @ConfigOption.Renderer("bazaarutils:item")
+    public String itemId = "minecraft:green_stained_glass_pane";
+
+    @ConfigEntry(
             id = "slot_index",
             translation = "bazaarutils.config.buttons.button.container.slot_index.label"
     )

--- a/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/features/gui/buttons/inputhelper/price/SellOfferPriceHelper.java
@@ -6,14 +6,12 @@ import com.github.mkram17.bazaarutils.utils.bazaar.gui.BazaarSlots;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.price.PricingPosition;
 import com.github.mkram17.bazaarutils.utils.minecraft.gui.ScreenManager;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
 import com.teamresourceful.resourcefulconfig.api.annotations.Comment;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigObject;
 import com.teamresourceful.resourcefulconfig.api.annotations.ConfigOption;
 import lombok.Getter;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 
 @Getter
@@ -70,14 +68,8 @@ public class SellOfferPriceHelper extends SignInputHelper.TransactionCost {
     public TransactionType transactionType = TransactionType.of(TransactionType.Side.SELL, TransactionType.Method.ORDER);
 
     @Override
-    public Item getButtonItem() {
-        return switch (getPricingPosition()) {
-            case COMPETITIVE -> Items.GREEN_STAINED_GLASS_PANE;
-            case MATCHED -> Items.YELLOW_STAINED_GLASS_PANE;
-            case OUTBID -> Items.ORANGE_STAINED_GLASS_PANE;
-        };
-    }
-
+    public ItemRef getItemRef() {
+        return ItemRef.of(this::getItemId);
     }
 
     @Override

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
@@ -6,19 +6,17 @@ import com.github.mkram17.bazaarutils.events.SlotClickEvent;
 import com.github.mkram17.bazaarutils.utils.SoundUtil;
 import com.github.mkram17.bazaarutils.utils.Util;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
-import com.github.mkram17.bazaarutils.utils.config.BUToggleableFeature;
 import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import lombok.Getter;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 
-public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton {
+public abstract class InputHelper<T> implements ItemButton {
     @Getter
     protected String name;
 
@@ -44,7 +42,7 @@ public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton 
     }
 
     public void onChestLoaded(ChestLoadedEvent event) {
-        if (!isEnabled() || !inCorrectScreen()) {
+        if (!inCorrectScreen()) {
             resetState();
 
             return;
@@ -54,8 +52,7 @@ public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton 
     }
 
     public void onReplaceItem(ReplaceItemEvent event) {
-        if (!(isEnabled()
-                && inCorrectScreen()
+        if (!(inCorrectScreen()
                 && state.isPresent()
                 && shouldReplaceItem(event))) {
             return;
@@ -70,9 +67,7 @@ public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton 
     }
 
     public void onSlotClicked(SlotClickEvent event) {
-        if (!(isEnabled()
-                && inCorrectScreen()
-                && wasButtonClicked(event))) {
+        if (!(inCorrectScreen() && wasButtonClicked(event))) {
             return;
         }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
@@ -75,7 +75,7 @@ public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton 
     public void onSlotClicked(SlotClickEvent event) {
         if (!(isEnabled()
                 && inCorrectScreen()
-                && wasButtonSlotClicked(event))) {
+                && wasButtonClicked(event))) {
             return;
         }
 

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
@@ -22,13 +22,10 @@ public abstract class InputHelper<T> implements BUToggleableFeature, ItemButton 
     @Getter
     protected String name;
 
-    protected abstract Item getButtonItem();
-
     /**
      * The market action which this helper is operating on (to buy, to sell; instant, order).
      */
     protected abstract TransactionType getTransactionType();
-
 
 //    Event cycle routines stuff
 

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/bazaar/InputHelper.java
@@ -6,7 +6,7 @@ import com.github.mkram17.bazaarutils.events.SlotClickEvent;
 import com.github.mkram17.bazaarutils.utils.SoundUtil;
 import com.github.mkram17.bazaarutils.utils.Util;
 import com.github.mkram17.bazaarutils.utils.bazaar.market.order.TransactionType;
-import com.github.mkram17.bazaarutils.utils.minecraft.ItemButton;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemButton;
 import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
 import lombok.Getter;
 import net.minecraft.component.DataComponentTypes;

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
@@ -1,21 +1,33 @@
 package com.github.mkram17.bazaarutils.utils.minecraft;
 
+import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
 import com.github.mkram17.bazaarutils.events.ReplaceItemEvent;
 import com.github.mkram17.bazaarutils.events.SlotClickEvent;
-import com.github.mkram17.bazaarutils.events.listener.BUListener;
-import com.teamresourceful.resourcefulconfig.api.annotations.ConfigEntry;
-import lombok.Getter;
-import lombok.Setter;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.StateItemGroup;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 
 public interface ItemButton {
-    RegistryEntry<SoundEvent> BUTTON_SOUND = SoundEvents.UI_BUTTON_CLICK;
-    float BUTTON_VOLUME = 0.2f;
-    int getSlotIndex();
+    Item DEFAULT_ITEM = Items.BARRIER;
 
+    float BUTTON_VOLUME = 0.2f;
+    RegistryEntry<SoundEvent> BUTTON_SOUND = SoundEvents.UI_BUTTON_CLICK;
+
+    int getSlotIndex();
+    ItemRef getItemRef();
+
+    default Item resolveItem() {
+        return switch (getItemRef()) {
+            case ItemRef.Direct(Item item) -> item;
+            case ItemRef.ById(var id) -> resolveId(id.get());
+            case ItemRef.Stateful<?> stateful -> resolveStateful(stateful);
+        };
+    }
 
     default ItemStack getReplacementItem(int size) {
         return new ItemStack(resolveItem(), size);
@@ -31,5 +43,29 @@ public interface ItemButton {
 
     default boolean wasButtonClicked(SlotClickEvent event) {
         return event.getSlotId() == getSlotIndex();
+    }
+
+    private static Item resolveId(String rawId) {
+        Item resolved = ResourcefulConfigItems.resolve(rawId);
+
+        return resolved != null ? resolved : DEFAULT_ITEM;
+    }
+
+    private static <S> Item resolveStateful(ItemRef.Stateful<S> stateful) {
+        Item resolved = stateful.source()
+                .map(source -> switch (source) {
+                    case ItemRef.Direct(Item item) -> item;
+                    case ItemRef.ById(var id) -> resolveId(id.get());
+                    case ItemRef.Stateful<?> ignored -> throw new IllegalStateException("Stateful ItemRef cannot nest another Stateful as its source");
+                })
+                .orElse(DEFAULT_ITEM);
+
+        S state = stateful.state().get();
+
+        for (StateItemGroup<S> group : stateful.groups()) {
+            if (group.contains(resolved)) return group.forState(state, resolved);
+        }
+
+        return resolved;
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
@@ -17,7 +17,13 @@ public interface ItemButton {
     int getSlotIndex();
 
 
-    ItemStack getReplacementItem();
+    default ItemStack getReplacementItem(int size) {
+        return new ItemStack(resolveItem(), size);
+    }
+
+    default ItemStack getReplacementItem() {
+        return getReplacementItem(1);
+    }
 
     default boolean shouldReplaceItem(ReplaceItemEvent event) {
         return event.getSlotId() == getSlotIndex();

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
@@ -29,7 +29,7 @@ public interface ItemButton {
         return event.getSlotId() == getSlotIndex();
     }
 
-    default boolean wasButtonSlotClicked(SlotClickEvent event) {
+    default boolean wasButtonClicked(SlotClickEvent event) {
         return event.getSlotId() == getSlotIndex();
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/ItemButton.java
@@ -14,16 +14,16 @@ import net.minecraft.sound.SoundEvents;
 public interface ItemButton {
     RegistryEntry<SoundEvent> BUTTON_SOUND = SoundEvents.UI_BUTTON_CLICK;
     float BUTTON_VOLUME = 0.2f;
+    int getSlotIndex();
 
-    int getSlotNumber();
 
     ItemStack getReplacementItem();
 
     default boolean shouldReplaceItem(ReplaceItemEvent event) {
-        return event.getSlotId() == getSlotNumber();
+        return event.getSlotId() == getSlotIndex();
     }
 
     default boolean wasButtonSlotClicked(SlotClickEvent event) {
-        return event.getSlotId() == getSlotNumber();
+        return event.getSlotId() == getSlotIndex();
     }
 }

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/components/CustomDataComponents.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/components/CustomDataComponents.java
@@ -12,10 +12,12 @@ import net.minecraft.util.Identifier;
 public final class CustomDataComponents {
     public static ComponentType<String> CUSTOM_SIZE;
     public static ComponentType<Boolean> SHOW_PRICE_CHART;
+    public static ComponentType<Boolean> SLOT_SELECTOR_LOCKED;
 
     public CustomDataComponents() {
         CUSTOM_SIZE = register("custom_size", ComponentType.<String>builder().codec(Codec.STRING).build());
         SHOW_PRICE_CHART = register("has_price_chart", ComponentType.<Boolean>builder().codec(Codec.BOOL).build());
+        SLOT_SELECTOR_LOCKED = register("slot_selector_locked", ComponentType.<Boolean>builder().codec(Codec.BOOL).build());
     }
 
     private static <T> ComponentType<T> register(String id, ComponentType<T> type) {

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemBuilder.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemBuilder.java
@@ -1,0 +1,72 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
+
+import com.github.mkram17.bazaarutils.utils.minecraft.components.CustomDataComponents;
+import it.unimi.dsi.fastutil.objects.ReferenceSortedSets;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.TooltipDisplayComponent;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+
+public final class ItemBuilder {
+    private final Item item;
+    private int count = 1;
+    private Text name = null;
+    private boolean locked = false;
+    private boolean hideTooltip = false;
+
+    private ItemBuilder(Item item) {
+        this.item = item;
+    }
+
+    public static ItemBuilder of(Item item) {
+        return new ItemBuilder(item);
+    }
+
+    public static ItemBuilder of(Item item, int count) {
+        return new ItemBuilder(item).count(count);
+    }
+
+    public ItemBuilder count(int count) {
+        this.count = count;
+        return this;
+    }
+
+    public ItemBuilder named(String name) {
+        return named(Text.literal(name));
+    }
+
+    public ItemBuilder named(Text name) {
+        this.name = name;
+        return this;
+    }
+
+    public ItemBuilder locked() {
+        this.locked = true;
+        return this;
+    }
+
+    public ItemBuilder hideTooltip() {
+        this.hideTooltip = true;
+        return this;
+    }
+
+    public ItemStack build() {
+        var stack = new ItemStack(item, count);
+
+        if (name != null) {
+            stack.set(DataComponentTypes.CUSTOM_NAME, name);
+        }
+        if (locked) {
+            stack.set(CustomDataComponents.SLOT_SELECTOR_LOCKED, true);
+        }
+
+        TooltipDisplayComponent tooltip = hideTooltip
+                ? new TooltipDisplayComponent(true, ReferenceSortedSets.emptySet())
+                : stack.getOrDefault(DataComponentTypes.TOOLTIP_DISPLAY, TooltipDisplayComponent.DEFAULT);
+
+        stack.set(DataComponentTypes.TOOLTIP_DISPLAY, tooltip.with(DataComponentTypes.ATTRIBUTE_MODIFIERS, true));
+
+        return stack;
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemButton.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemButton.java
@@ -1,10 +1,9 @@
-package com.github.mkram17.bazaarutils.utils.minecraft;
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
 
 import com.github.mkram17.bazaarutils.config.util.api.ResourcefulConfigItems;
 import com.github.mkram17.bazaarutils.events.ReplaceItemEvent;
 import com.github.mkram17.bazaarutils.events.SlotClickEvent;
-import com.github.mkram17.bazaarutils.utils.minecraft.item.ItemRef;
-import com.github.mkram17.bazaarutils.utils.minecraft.item.StateItemGroup;
+import com.github.mkram17.bazaarutils.utils.minecraft.item.groups.StateItemGroup;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemGroups.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemGroups.java
@@ -1,0 +1,39 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+
+import java.util.Set;
+
+public final class ItemGroups {
+    private ItemGroups() {}
+
+    public static final Set<Item> GLASS_PANES = Set.of(
+            Items.GLASS_PANE,
+            Items.WHITE_STAINED_GLASS_PANE, Items.ORANGE_STAINED_GLASS_PANE,
+            Items.MAGENTA_STAINED_GLASS_PANE, Items.LIGHT_BLUE_STAINED_GLASS_PANE,
+            Items.YELLOW_STAINED_GLASS_PANE, Items.LIME_STAINED_GLASS_PANE,
+            Items.PINK_STAINED_GLASS_PANE, Items.GRAY_STAINED_GLASS_PANE,
+            Items.LIGHT_GRAY_STAINED_GLASS_PANE, Items.CYAN_STAINED_GLASS_PANE,
+            Items.PURPLE_STAINED_GLASS_PANE, Items.BLUE_STAINED_GLASS_PANE,
+            Items.BROWN_STAINED_GLASS_PANE, Items.GREEN_STAINED_GLASS_PANE,
+            Items.RED_STAINED_GLASS_PANE, Items.BLACK_STAINED_GLASS_PANE
+    );
+
+    public static final Set<Item> GLASS_BLOCKS = Set.of(
+            Items.GLASS,
+            Items.WHITE_STAINED_GLASS, Items.ORANGE_STAINED_GLASS,
+            Items.MAGENTA_STAINED_GLASS, Items.LIGHT_BLUE_STAINED_GLASS,
+            Items.YELLOW_STAINED_GLASS, Items.LIME_STAINED_GLASS,
+            Items.PINK_STAINED_GLASS, Items.GRAY_STAINED_GLASS,
+            Items.LIGHT_GRAY_STAINED_GLASS, Items.CYAN_STAINED_GLASS,
+            Items.PURPLE_STAINED_GLASS, Items.BLUE_STAINED_GLASS,
+            Items.BROWN_STAINED_GLASS, Items.GREEN_STAINED_GLASS,
+            Items.RED_STAINED_GLASS, Items.BLACK_STAINED_GLASS
+    );
+
+    public static final StateItemGroup<Boolean> BOOKMARKED_STATE_GROUP = StateItemGroup.<Boolean>any()
+            .on(true, Items.GREEN_STAINED_GLASS_PANE)
+            .on(false, Items.RED_STAINED_GLASS_PANE)
+            .build();
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemRef.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemRef.java
@@ -1,0 +1,43 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
+
+import net.minecraft.item.Item;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public sealed interface ItemRef {
+    record Direct(Item item) implements ItemRef {}
+    record ById(Supplier<String> id) implements ItemRef {}
+    record Stateful<S>(Optional<ItemRef> source, Supplier<S> state, List<StateItemGroup<S>> groups) implements ItemRef {
+        static <S> Stateful<S> of(Supplier<S> state, List<StateItemGroup<S>> groups) {
+            return new Stateful<>(Optional.empty(), state, groups);
+        }
+    }
+
+    static ItemRef of(Item item) {
+        return new Direct(item);
+    }
+
+    static ItemRef of(String id) {
+        return new ById(() -> id);
+    }
+
+    static ItemRef of(Supplier<String> id) {
+        return new ById(id);
+    }
+
+    @SafeVarargs
+    static <S> ItemRef of(ItemRef source, Supplier<S> state, StateItemGroup<S>... groups) {
+        return new Stateful<>(Optional.of(source), state, List.of(groups));
+    }
+
+    static <S> ItemRef of(Supplier<S> state, StateItemGroup<S> group) {
+        return Stateful.of(state, List.of(group));
+    }
+
+    @SafeVarargs
+    static <S> ItemRef of(Supplier<S> state, StateItemGroup<S>... groups) {
+        return Stateful.of(state, List.of(groups));
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemRef.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/ItemRef.java
@@ -1,5 +1,6 @@
 package com.github.mkram17.bazaarutils.utils.minecraft.item;
 
+import com.github.mkram17.bazaarutils.utils.minecraft.item.groups.StateItemGroup;
 import net.minecraft.item.Item;
 
 import java.util.List;

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/StateItem.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/StateItem.java
@@ -1,0 +1,16 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
+
+import net.minecraft.item.Item;
+
+public sealed interface StateItem {
+    record Fixed(Item item) implements StateItem {}
+    record Configured() implements StateItem {}
+
+    static StateItem of(Item item) {
+        return new Fixed(item);
+    }
+
+    static StateItem configured() {
+        return new Configured();
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/StateItemGroup.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/StateItemGroup.java
@@ -1,0 +1,80 @@
+package com.github.mkram17.bazaarutils.utils.minecraft.item;
+
+import net.minecraft.item.Item;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record StateItemGroup<S>(Set<Item> recognized, Map<S, StateItem> states) {
+    /**
+     * Unit type for StateGroup recognition — matches any configured item regardless of family.
+     * <p>
+     *     Identity-checked via {@code ==} in {@link #contains(Item)}, never iterated or queried for membership.
+     * </p>
+     */
+    public static final Set<Item> ANY = Set.of();
+
+    public boolean contains(Item item) {
+        return recognized == ANY || recognized.contains(item);
+    }
+
+    public Item forState(S state, Item configured) {
+        StateItem stateItem = states.getOrDefault(state, StateItem.configured());
+
+        return switch (stateItem) {
+            case StateItem.Fixed(Item item) -> item;
+            case StateItem.Configured() -> configured;
+        };
+    }
+
+    /**
+     * A factory which defaults the recognized set to the unit type {@link #ANY},
+     * albeit that it will encompass any item regardless of family or type,
+     * and route it through the state map unconditionally.
+     */
+    public static <S> Builder<S> any() {
+        return new Builder<>(ANY);
+    }
+
+    public static <S> Builder<S> of(Set<Item> recognized) {
+        return new Builder<>(recognized);
+    }
+
+    public static <S> StateItemGroup<S> of(Set<Item> recognized, Map<S, StateItem> states) {
+        return new StateItemGroup<>(recognized, states);
+    }
+
+    public static <S> StateItemGroup<S> of(Map<S, StateItem> states) {
+        Set<Item> recognized = states.values().stream()
+                .filter(state -> state instanceof StateItem.Fixed)
+                .map(state -> ((StateItem.Fixed) state).item())
+                .collect(Collectors.toSet());
+
+        return new StateItemGroup<>(recognized, states);
+    }
+
+    public static final class Builder<S> {
+        private final Set<Item> recognized;
+        private final Map<S, StateItem> states = new LinkedHashMap<>();
+
+        private Builder(Set<Item> recognized) {
+            this.recognized = recognized;
+        }
+
+        public Builder<S> on(S state, Item item) {
+            states.put(state, StateItem.of(item));
+            return this;
+        }
+
+        public Builder<S> configured(S state) {
+            states.put(state, StateItem.configured());
+            return this;
+        }
+
+        public StateItemGroup<S> build() {
+            return new StateItemGroup<>(recognized, Map.copyOf(states));
+        }
+    }
+}

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/groups/ItemGroups.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/groups/ItemGroups.java
@@ -1,4 +1,4 @@
-package com.github.mkram17.bazaarutils.utils.minecraft.item;
+package com.github.mkram17.bazaarutils.utils.minecraft.item.groups;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.Items;

--- a/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/groups/StateItemGroup.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/utils/minecraft/item/groups/StateItemGroup.java
@@ -1,5 +1,6 @@
-package com.github.mkram17.bazaarutils.utils.minecraft.item;
+package com.github.mkram17.bazaarutils.utils.minecraft.item.groups;
 
+import com.github.mkram17.bazaarutils.utils.minecraft.item.StateItem;
 import net.minecraft.item.Item;
 
 import java.util.LinkedHashMap;

--- a/src/main/resources/assets/bazaarutils/lang/en_us.json5
+++ b/src/main/resources/assets/bazaarutils/lang/en_us.json5
@@ -68,6 +68,13 @@
   "mod.bazaarutils": "Bazaar Utils",
   "key.category.minecraft.bazaarutils": "Bazaar Utils",
 
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Search...",
+      "select": "Select"
+    }
+  },
+
   "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
     "not_upgraded.label": "Not Upgraded",
     "first_tier.label": "Bazaar Flipper I",

--- a/src/main/resources/assets/bazaarutils/lang/en_us.json5
+++ b/src/main/resources/assets/bazaarutils/lang/en_us.json5
@@ -165,7 +165,7 @@
             "label": "Enabled",
             "hint": "Whether the button will be enabled."
           },
-          "slot_number.{}": {
+          "slot_index.{}": {
             "label": "Slot Number",
             "hint": "The container slot where the button will be placed."
           },

--- a/src/main/resources/assets/bazaarutils/lang/en_us.json5
+++ b/src/main/resources/assets/bazaarutils/lang/en_us.json5
@@ -213,48 +213,24 @@
       "helpers.{}": {
         "category.label": "Input Helpers",
 
-        "buy_order_amount.{}": {
-          "separator.label": "Buy Order Amount",
-          "label": "Buy Order Amount",
-          "hint": "Places an item at the desired slot, which when clicked will input as the amount for this order the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
+        "separator.buy_related.{}": {
+          "label": "Buy Helpers",
+          "hint": "Helpers that appear when buying stuff off the Bazaar. Configure buttons to auto-fill amounts or prices when instant buying or placing buy orders."
         },
 
-        "instant_buy_amount.{}": {
-          "separator.label": "Instant Buy Amount",
-          "label": "Instant Buy Amount",
-          "hint": "Places an item at the desired slot, which when clicked will input as the amount for this purchase the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
+        "instant_buy_amount.label": "Instant Buy Amount",
+        "buy_order_amount.label": "Buy Order Amount",
+        "buy_order_price.label": "Buy Order Price",
+
+        "separator.sell_related.{}": {
+          "label": "Sell Helpers",
+          "hint": "Helpers that appear when selling stuff in the Bazaar. Configure buttons to auto-fill amounts or prices when placing sell offers or flipping orders."
         },
 
-        "sell_offer_amount.{}": {
-          "separator.label": "Sell Offer Amount",
-          "label": "Sell Offer Amount",
-          "hint": "Places an item at the desired slot, which when clicked will input as the amount for this offer the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
-        },
-
-        "buy_order_price.{}": {
-          "separator.label": "Buy Order Price",
-          "label": "Buy Order Price",
-          "hint": "Places an item at the desired slot, which when clicked will input as the price for this order the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
-        },
-
-        "sell_offer_price.{}": {
-          "separator.label": "Sell Offer Price",
-          "label": "Sell Offer Price",
-          "hint": "Places an item at the desired slot, which when clicked will input as the price for this offer the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
-        },
-
-        "flip_order_price.{}": {
-          "separator.label": "Flip Order Price",
-          "label": "Flip Order Price",
-          "hint": "Places an item at the desired slot, which when clicked will input as the price for this flip the computed, configurable, value.",
-          "{}.label": ["First Button", "Second Button", "Third Button"]
-        }
-      }
+        "flip_order_price.label": "Flip Order Price",
+        "sell_offer_amount.label": "Sell Offer Amount",
+        "sell_offer_price.label": "Sell Offer Price",
+      },
     },
 
     "inventory.{}": {

--- a/src/main/resources/assets/bazaarutils/lang/en_us.json5
+++ b/src/main/resources/assets/bazaarutils/lang/en_us.json5
@@ -165,6 +165,10 @@
             "label": "Enabled",
             "hint": "Whether the button will be enabled."
           },
+          "item_id.{}": {
+            "label": "Item",
+            "hint": "The item that will be placed as the button."
+          },
           "slot_index.{}": {
             "label": "Slot Number",
             "hint": "The container slot where the button will be placed."


### PR DESCRIPTION
depends on #73 

# changelog

- Refactors the ItemButton interface semantics to more proper match how we consume those fields:
  - `slotNumber` -> `slotIndex` https://github.com/mkram17/Bazaar-Utils/commit/110757abd4ee1ddbb81d08cabc3b244bb2795e72
  - `wasButtonSlotClicked` -> `wasButtonClicked` https://github.com/mkram17/Bazaar-Utils/commit/51735e678c06d27782ba66857d62ebfceb44823a
- Refactors the ItemButton's itemstack-retrieving routine to be that of a sealed interface, whereas implementations may consume any of the following:
  - `ById`, a strategy which is to be consumed by features which resolve their item by identifier. https://github.com/mkram17/Bazaar-Utils/commit/e36cc949d1cbb49d43b6ff662402a68ad35e9b79
    - The Id lookup & identifier parsing is cached by the item registry
  - `Direct`, a strategy which is to be consumed by features which resolve their item statically, albeit, it is not configurable. https://github.com/mkram17/Bazaar-Utils/commit/e36cc949d1cbb49d43b6ff662402a68ad35e9b79
  - `Stateful`, a strategy which accepts a supplier of state and a StateItemGroup which is generic to the state. It is to be consumed by features which want to shift the button item depending on some state. https://github.com/mkram17/Bazaar-Utils/commit/e36cc949d1cbb49d43b6ff662402a68ad35e9b79
    - This really is a abstraction which could be convexed/dropped in favor of just if/else'ing at the item ref accessor, but 1) the routines relevant to resolve to a item stack are ran once per frame; 2) hash-map lookups are virtually as fast as a switch/a if condition.  
- Consume [Container Renderers](https://github.com/mkram17/Bazaar-Utils/pull/73) on features
  - All Helpers may configure both their slot and their item https://github.com/0xar-ds/Bazaar-Utils/commit/c1011516584d5ab38f6950f2168fae71b7cfa7bf https://github.com/0xar-ds/Bazaar-Utils/commit/1d2eed541d8c9c9674afc7ac2cb765d999e6b101
  - The Button to toggle a bookmark is fixed to slot 0 as well as the item shifts between the items which were prior behaviour https://github.com/0xar-ds/Bazaar-Utils/commit/c1011516584d5ab38f6950f2168fae71b7cfa7bf https://github.com/0xar-ds/Bazaar-Utils/commit/1d2eed541d8c9c9674afc7ac2cb765d999e6b101 
- [Slot Providers](https://github.com/mkram17/Bazaar-Utils/pull/73#issue-4020258476) that this PR consumes were populated by https://github.com/0xar-ds/Bazaar-Utils/commit/5d7129b94612ebea0c97ba8822e451cdd78bb2dd, and those providers were populated with their feature set by https://github.com/0xar-ds/Bazaar-Utils/commit/c217afa51f3d31ee68d9557b5fc96104b61f9b01
  - Do note the trailer of that commit, we should really aim to have a sole definition of screens. Whether they'd be static or remote. Also, we should aim with 1:1 looks of the related screen, as filling those item stacks of lore is something that it's done on a sole frame and at a configuration standpoint of the mod: it's better user experience and there are no tradeoffs to it.
- Input Helpers were refactored to consume List<? @ConfigObject> #90 https://github.com/0xar-ds/Bazaar-Utils/commit/3a1247128634a64b803c481ec0c17d6b24987bc2 https://github.com/0xar-ds/Bazaar-Utils/commit/ceaf1f40d35c227d608f943dd80e2817a4f30848
  - Sadly there's a field/a list per each InputHelper concrete. I did consider on the upstream PR supporting list of interfaces with selectable concretes, but that idea was not reviewed/confirmed by maintainers (https://github.com/Team-Resourceful/Resourceful-Config/pull/54#issuecomment-4021458169)   
  
# examples

## ItemButton 

### A feature which consumes the new interface

```java
@Module
public class MyButton extends BUListener implements ItemButton {
    @Override
    public int getSlotIndex() {
        return 0;
    }

    @Override
    public ItemRef getItemRef() {
        return ItemRef.of(Items.BARRIER);
    }

    public MyButton() {}

    @EventHandler
    private void onReplaceItemEvent(ReplaceItemEvent event) {
        if (!shouldReplaceItem(event) || !inCorrectScreen()) return;

        event.setReplacement(getReplacementItem());
    }
}
```

### and allows the user to configure both the index and the button item

```java
@Getter
@ConfigObject
public class MyButton extends BUListener implements ItemButton {
    @ConfigEntry(...)
    @Comment(...)
    @ContainerSlot(...)
    @ConfigOption.Range(...)
    @ConfigOption.Renderer("bazaarutils:slot")
    public int slotIndex;

    @ConfigEntry(...)
    @Comment(...)
    @ConfigOption.Renderer("bazaarutils:item")
    public String itemId = "minecraft:green_stained_glass_pane";

    @Override
    public ItemRef getItemRef() {
        return ItemRef.of(this::getItemId);
    }

    public MyButton() {}

    @EventHandler
    private void onReplaceItemEvent(ReplaceItemEvent event) {
        if (!shouldReplaceItem(event) || !inCorrectScreen()) return;

        event.setReplacement(getReplacementItem());
    }
}
```

### and shifts through state

```java
@Getter
@ConfigObject
public class MyButton extends BUListener implements ItemButton {
    @ConfigEntry(...)
    @Comment(...)
    @ContainerSlot(...)
    @ConfigOption.Range(...)
    @ConfigOption.Renderer("bazaarutils:slot")
    public int slotIndex;

    @ConfigEntry(...)
    @Comment(...)
    @ConfigOption.Renderer("bazaarutils:item")
    public String itemId = "minecraft:green_stained_glass_pane";

    private transient PricingPosition pricingPosition = PricingPosition.MATCHED;

    private static final Set<Item> GLASS_PANES_FAMILY = Set.of(
            Items.GLASS_PANE,
            Items.WHITE_STAINED_GLASS_PANE, Items.ORANGE_STAINED_GLASS_PANE,
            Items.MAGENTA_STAINED_GLASS_PANE, Items.LIGHT_BLUE_STAINED_GLASS_PANE,
            Items.YELLOW_STAINED_GLASS_PANE, Items.LIME_STAINED_GLASS_PANE,
            Items.PINK_STAINED_GLASS_PANE, Items.GRAY_STAINED_GLASS_PANE,
            Items.LIGHT_GRAY_STAINED_GLASS_PANE, Items.CYAN_STAINED_GLASS_PANE,
            Items.PURPLE_STAINED_GLASS_PANE, Items.BLUE_STAINED_GLASS_PANE,
            Items.BROWN_STAINED_GLASS_PANE, Items.GREEN_STAINED_GLASS_PANE,
            Items.RED_STAINED_GLASS_PANE, Items.BLACK_STAINED_GLASS_PANE
    );

    public static final StateItemGroup<PricingPosition> PANE_PRICING_POSITION_GROUP = StateItemGroup.of(GLASS_PANES_FAMILY) // the item family under which this state group activates; if itemId configured is not existential to this group, whichever item was selected is rendered no matter the state. 
        .on(PricingPosition.COMPETITIVE, Items.LIME_STAINED_GLASS_PANE)
        .configured(PricingPosition.MATCHED)   // user's neutral pane shows through when at market
        .on(PricingPosition.OUTBID,   Items.RED_STAINED_GLASS_PANE)
        .build();

     @Override
     public ItemRef getItemRef() {
         return ItemRef.of(
             ItemRef.of(this::getItemId),
             this::getPricingPosition,
             PANE_PRICING_POSITION_GROUP
         );
     }

    public MyButton() {}

    @EventHandler
    private void onReplaceItemEvent(ReplaceItemEvent event) {
        if (!shouldReplaceItem(event) || !inCorrectScreen()) return;

        event.setReplacement(getReplacementItem());
    }
}
```

# renders

<img width="1920" height="1080" alt="hScHx232RejfvsuL" src="https://github.com/user-attachments/assets/c35dbf5d-0e9f-449c-a348-f0a4651292dd" />
<img width="1920" height="1080" alt="zgrHy7YJjCyZPGVe" src="https://github.com/user-attachments/assets/c3f15b12-f680-485c-82ec-2b2e8d8fef42" />
<img width="1920" height="1080" alt="HmZcsxux57NGwphZ" src="https://github.com/user-attachments/assets/3611633c-84be-4782-8665-41942f1001d2" />
<img width="1920" height="1080" alt="HdB46mcD5KSGVQDS" src="https://github.com/user-attachments/assets/77109656-454f-4530-abc3-d3108502846c" />


<img width="1920" height="1080" alt="6f6sfSeRf6EoSGJB" src="https://github.com/user-attachments/assets/2aca989b-f078-4d4b-bb3b-fe4f30ad2392" />
<img width="1920" height="1080" alt="rTFaUjXERVQTm6bm" src="https://github.com/user-attachments/assets/7fdae0b8-af22-42de-b56f-6d0a1334638b" />
