### PR TITLE
Fix: StackOverflowError in Bazaar menus with SkyBlockAPI/SkyOcean

### DIFF
--- a/UPDATES.MD
+++ b/UPDATES.MD
@@ -1,1 +1,1 @@
-- Fix bug causing the Mining page to be detected as an item page
+- Fixed StackOverflowError crash when loaded with Skyblock-API/SkyOcean caused by recursive ReplaceItemEvent loops

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ fabric_kotlin_version=1.13.1+kotlin.2.1.10
 
 mod_version=0.6.2
 mod_release_channel=beta
-mod_prerelease_number=3
+mod_prerelease_number=4
 major_update_notes=v0.6 Update: Too many changes to note here, but user experience is greatly improved. Check the changelog on the Modrinth page/GitHub for more details!
 
 maven_group=com.github.mkram17.bazaarutils

--- a/src/main/java/com/github/mkram17/bazaarutils/mixin/MixinSimpleInventory.java
+++ b/src/main/java/com/github/mkram17/bazaarutils/mixin/MixinSimpleInventory.java
@@ -8,27 +8,37 @@ import net.minecraft.util.collection.DefaultedList;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-//used for ReplaceItemEvent
 @Mixin(SimpleInventory.class)
 public abstract class MixinSimpleInventory {
     @Final
     @Shadow
     public DefaultedList<ItemStack> heldStacks;
 
+    // Prevents recursive StackOverflow when other mods (Skyblock-API, SkyOcean)
+    // hook ItemStack construction and read inventory slots to resolve SkyBlock IDs.
+    @Unique
+    private static final ThreadLocal<Boolean> REPLACING = ThreadLocal.withInitial(() -> false);
 
-    @Inject(method = "getStack(I)Lnet/minecraft/item/ItemStack;",at = @At("HEAD"), cancellable = true)
+    @Inject(method = "getStack(I)Lnet/minecraft/item/ItemStack;", at = @At("HEAD"), cancellable = true)
     private void onGetStack(int slot, CallbackInfoReturnable<ItemStack> cir) {
         if (slot < 0 || slot >= this.heldStacks.size()) return;
+        if (REPLACING.get()) return;
 
-        ReplaceItemEvent event = new ReplaceItemEvent(this.heldStacks.get(slot),(SimpleInventory) (Object) this,slot);
-        BazaarUtils.EVENT_BUS.post(event);
+        REPLACING.set(true);
+        try {
+            ReplaceItemEvent event = new ReplaceItemEvent(this.heldStacks.get(slot), (SimpleInventory) (Object) this, slot);
+            BazaarUtils.EVENT_BUS.post(event);
 
-        if (event.getReplacement() != event.getOriginal()) {
-            cir.setReturnValue(event.getReplacement());
+            if (event.getReplacement() != event.getOriginal()) {
+                cir.setReturnValue(event.getReplacement());
+            }
+        } finally {
+            REPLACING.set(false);
         }
     }
 }


### PR DESCRIPTION
### Problem
When opening Bazaar "Buy Order" or "Instant Buy" menus alongside mods that hook `ItemStack` initialization (e.g. SkyBlockAPI, SkyOcean), the game spams `StackOverflowError` in logs and the menu becomes non-functional (buttons don't render correctly, clicks don't work). The menu stays broken until closed.

This happens because `MixinSimpleInventory.onGetStack()` fires a `ReplaceItemEvent` that creates a new `ItemStack`, which triggers other mods' init hooks, which call back into `Inventory.getStack()`, re-entering our Mixin infinitely.

### Fix
Added a `ThreadLocal<Boolean>` reentrancy guard in `MixinSimpleInventory` to prevent recursive event posting. The guard is set before firing the event and cleared in a `try/finally` block.