### PR TITLE
Add German, Polish, French, Chinese and Russian translations

### DIFF
--- a/src/main/resources/assets/bazaarutils/lang/de_de.json5
+++ b/src/main/resources/assets/bazaarutils/lang/de_de.json5
@@ -1,0 +1,429 @@
+{
+  "owo:extended_lang": true,
+
+  "bazaarutils.ref.{}": {
+    "instant_sell": [{
+      "text": "Instant Sell",
+      "color": "green"
+    }],
+
+    "booster_cookie": [{
+      "text": "Booster Cookie",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Booster Cookie\n", "color": "light_purple", "bold": true },
+          { "text": "Gewährt Zugriff auf die Bazaar-Order-API\nund weitere SkyBlock-Vorteile.\n\n", "color": "gray" },
+          { "text": "↗ Klicken, um das Wiki zu öffnen", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Booster_Cookie"
+      }
+    }],
+
+    "bazaar_flipper": [{
+      "text": "Bazaar Flipper",
+      "color": "gold",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Bazaar Flipper\n", "color": "gold", "bold": true },
+          { "text": "Ein Account Upgrade, das die Steuer senkt\nund dein Limit an aktiven Orders erhöht.\n\n", "color": "gray" },
+          { "text": "↗ Klicken, um das Wiki zu öffnen", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Bazaar_Flipper"
+      }
+    }],
+
+    "elizabeth": [{
+      "text": "Elizabeth",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Elizabeth\n", "color": "light_purple", "bold": true },
+          { "text": "NPC im ", "color": "gray" },
+          { "text": "Community Center", "color": "gray" },
+          { "text": " im SkyBlock Hub.\n", "color": "gray" },
+          { "text": "Verkauft Account Upgrades für Gems.\n\n", "color": "gray" },
+          { "text": "↗ Klicken, um das Wiki zu öffnen", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Elizabeth"
+      }
+    }],
+
+    "community_center": [{ "text": "Community Center", "color": "aqua" }],
+    "skyblock_hub": [{ "text": "SkyBlock Hub", "color": "aqua" }]
+  },
+
+  "mod.bazaarutils": "Bazaar Utils",
+  "key.category.minecraft.bazaarutils": "Bazaar Utils",
+
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Suchen...",
+      "select": "Auswählen"
+    }
+  },
+
+  "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
+    "not_upgraded.label": "Nicht verbessert",
+    "first_tier.label": "Bazaar Flipper I",
+    "second_tier.label": "Bazaar Flipper II"
+  },
+
+  "bazaarutils.config.{}": {
+
+    "separator.introductory.label": "Willkommen bei Bazaar Utils!",
+    "separator.introductory.hint": "Danke, dass du Bazaar Utils installiert hast! Diese Mod bietet Komfortfunktionen für den Hypixel-Bazaar.",
+
+    "bazaar_flipper_account_upgrade.{}": {
+      "label": "Bazaar Flipper Account Upgrade",
+      "hint": [
+        "Die Stufe deines ", { "translate": "bazaarutils.ref.bazaar_flipper" },
+        " Account Upgrades, die bei der Steuerberechnung und den aktuellen Order-Limits berücksichtigt wird.",
+        "\nDeine Bazaar-Flipper-Stufe kannst du erhöhen, indem du mit ",
+        { "translate": "bazaarutils.ref.elizabeth" }, " im ",
+        { "translate": "bazaarutils.ref.community_center" }, " im ",
+        { "translate": "bazaarutils.ref.skyblock_hub" }, " sprichst."
+      ]
+    },
+
+    "chat.{}": {
+      "category.label": "Chat",
+      "category.hint": "Konfigurationen für die Chat-Funktionen der Mod",
+
+      "separator.useless_bazaar_notifications_remover.label": "Nutzlose Bazaar-Benachrichtigungen",
+      "useless_bazaar_notifications_remover.{}": {
+        "label": "Nutzlose Bazaar-Benachrichtigungen",
+        "hint": "Entfernt bestimmte kurzlebige Nachrichten, die beim Interagieren mit dem Bazaar im Chat erscheinen, um Unordnung zu reduzieren.",
+        "excluded_notifications.{}": {
+          "label": "Ausgeschlossene Benachrichtigungen",
+          "hint": "Eine Liste von Nachrichten und Benachrichtigungen, die im Chat blockiert werden."
+        }
+      },
+
+      "separator.stash_messages_remover.label": "Stash-Nachrichten",
+      "stash_messages_remover.{}": {
+        "label": "Stash-Nachrichten",
+        "hint": "Entfernt Chat-Nachrichten, die dich daran erinnern, Gegenstände aus deinem Stash abzuholen."
+      }
+    },
+
+    "buttons.{}": {
+      "category.label": "Schaltflächen",
+      "category.hint": "Konfigurationen für die Schaltflächen, die von der Mod eingefügt/verwaltet werden",
+
+      "separator.mod_buttons.{}": {
+        "label": "Mod-Schaltflächen",
+        "hint": "Fügt Inventar-Menüs Schaltflächen für den schnellen Zugriff auf Mod-Funktionen hinzu."
+      },
+
+      "open_settings.{}": {
+        "label": "Schaltfläche für Mod-Einstellungen",
+        "hint": "Fügt ausgewählten Menüs eine Schaltfläche für den schnellen Zugriff auf die Einstellungen der Mod hinzu."
+      },
+
+      "open_orders.{}": {
+        "label": "Schaltfläche für Orders-Seite",
+        "hint": [
+          "Fügt ausgewählten Menüs eine Schaltfläche für den schnellen Zugriff auf deine Orders-Seite hinzu.",
+          "\n\nErfordert einen aktiven ", { "translate": "bazaarutils.ref.booster_cookie" }, "."
+        ]
+      },
+
+      "separator.container_buttons.{}": {
+        "label": "Container-Schaltflächen",
+        "hint": "Fügt bestimmten Container-Oberflächen Hilfsschaltflächen hinzu."
+      },
+
+      "cancel_order_and_search.{}": {
+        "label": "Abbrechen-&-Suchen-Schaltfläche",
+        "hint": "Fügt Seiten mit unerfüllten Orders/Angeboten eine Schaltfläche hinzu, um die Order abzubrechen und sofort erneut nach dem Gegenstand zu suchen."
+      },
+
+      "button.{}": {
+        "widget.{}": {
+          "enabled.{}": {
+            "label": "Aktiviert",
+            "hint": "Ob die Schaltfläche aktiviert ist."
+          },
+          "size.label": "Schaltflächengröße",
+          "spacing.label": "Abstand"
+        },
+        "container.{}": {
+          "enabled.{}": {
+            "label": "Aktiviert",
+            "hint": "Ob die Schaltfläche aktiviert ist."
+          },
+          "item_id.{}": {
+            "label": "Gegenstand",
+            "hint": "Der Gegenstand, der als Schaltfläche platziert wird."
+          },
+          "slot_index.{}": {
+            "label": "Slot-Nummer",
+            "hint": "Der Container-Slot, in dem die Schaltfläche platziert wird."
+          },
+          "amount_strategy.{}": {
+            "label": "Mengenstrategie",
+            "hint": "Die Strategie, mit der der Mengenwert berechnet wird.\n\nMAX: Bestellt die maximale Menge, die du für die jeweilige Aktion (Instant, Order) bestellen kannst.\nFIXED: Bestellt die Menge, die du unten konfiguriert hast."
+          },
+          "pricing_position.{}": {
+            "label": "Preisposition",
+            "hint": "Die Strategie, mit der der Gebotspreis pro Gegenstand berechnet wird\n\nCOMPETITIVE: Das Gebot liegt +0,1 über dem aktuell besten Angebot am Markt\nMATCHED: Das Gebot entspricht dem aktuell besten Angebot am Markt\nOUTBID: Das Gebot liegt -0,1 unter dem aktuell besten Angebot am Markt"
+          },
+          "fixed_amount.{}": {
+            "label": "Feste Menge",
+            "hint": "Die Menge, die verwendet wird, wenn FIXED als Mengenstrategie eingestellt ist."
+          }
+        }
+      },
+
+      "bookmarks.{}": {
+        "category.label": "Lesezeichen",
+
+        "separator.introductory.{}": {
+          "label": "Gegenstands-Lesezeichen",
+          "hint": "Mit Gegenstands-Lesezeichen kannst du schnell nach bestimmten Gegenständen im Bazaar suchen."
+        },
+
+        "open_bookmark.{}": {
+          "label": "Lesezeichen öffnen",
+          "hint": "Konfiguriert die Schaltfläche in ausgewählten Menüs, die schnell nach dem gespeicherten Gegenstand sucht."
+        },
+
+        "toggle_bookmark.{}": {
+          "label": "Lesezeichen setzen",
+          "hint": "Fügt Gegenstandsseiten eine Schaltfläche hinzu, um das Lesezeichen für den schnellen Zugriff umzuschalten."
+        },
+
+        "reset_bookmarks.label": "Gespeicherte Lesezeichen",
+        "reset_bookmarks.runnable": "Zurücksetzen"
+      },
+
+      "helpers.{}": {
+        "category.label": "Eingabehilfen",
+
+        "separator.buy_related.{}": {
+          "label": "Kaufhilfen",
+          "hint": "Hilfen, die beim Kaufen im Bazaar erscheinen. Konfiguriere Schaltflächen, die Mengen oder Preise beim Sofortkauf oder beim Platzieren von Kauf-Orders automatisch ausfüllen."
+        },
+
+        "instant_buy_amount.label": "Sofortkauf-Menge",
+        "buy_order_amount.label": "Kauf-Order-Menge",
+        "buy_order_price.label": "Kauf-Order-Preis",
+
+        "separator.sell_related.{}": {
+          "label": "Verkaufshilfen",
+          "hint": "Hilfen, die beim Verkaufen im Bazaar erscheinen. Konfiguriere Schaltflächen, die Mengen oder Preise beim Platzieren von Verkaufsangeboten oder beim Flippen von Orders automatisch ausfüllen."
+        },
+
+        "flip_order_price.label": "Flip-Order-Preis",
+        "sell_offer_amount.label": "Verkaufsangebots-Menge",
+        "sell_offer_price.label": "Verkaufsangebots-Preis"
+      }
+    },
+
+    "inventory.{}": {
+      "category.label": "Inventar",
+      "category.hint": "Konfigurationen für die Inventar-Funktionen der Mod",
+
+      "separator.instant_sell_highlight.label": "Instant-Sell-Hervorhebung",
+      "instant_sell_highlight.{}": {
+        "label": "Instant-Sell-Hervorhebung",
+        "hint": [
+          "Hebt Gegenstände in deinem Inventar hervor, die von der Instant-Sell-Schaltfläche verkauft würden."
+        ],
+        "color.label": "Hervorhebungsfarbe"
+      },
+
+      "separator.order_status_highlight.label": "Order-Status-Hervorhebung",
+      "order_status_highlight.{}": {
+        "label": "Order-Status-Hervorhebung",
+        "hint": "Hebt den Status deiner Bazaar-Orders hervor, indem die Gegenstände in passenden Farben eingefärbt werden.",
+
+        "competitive_color.{}": {
+          "label": "Farbe für „Bestes Angebot“",
+          "hint": "Die Hervorhebungsfarbe für Orders, die aktuell das beste Angebot am Markt sind."
+        },
+
+        "matched_color.{}": {
+          "label": "Farbe für „Gleichauf“",
+          "hint": "Die Hervorhebungsfarbe für Orders, die dem aktuellen Marktpreis entsprechen."
+        },
+
+        "outbid_color.{}": {
+          "label": "Farbe für „Überboten“",
+          "hint": "Die Hervorhebungsfarbe für Orders, die überboten wurden."
+        }
+      },
+
+      "restrictions.{}": {
+        "separator.introductory.{}": {
+          "label": "Inventar-Einschränkungen"
+        },
+
+        "category.label": "Inventar-Einschränkungen",
+
+        "enabled.{}": {
+          "label": "Inventar-Einschränkungen",
+          "hint": "Sperrt ausgewählte Bazaar-Schaltflächen anhand von Inventar- oder Aktionskriterien, um versehentliche Marktaktionen zu verhindern."
+        },
+
+        "features.{}": {
+          "label": "Eingeschränkte Schaltflächen",
+          "hint": "Die Inventar-Schaltflächen, für die Einschränkungen aktiviert sind.",
+
+          "target.{}": {
+            "instant_sell.label": "Instant Sell",
+            "sell_sacks.label": "Sell Sacks"
+          }
+        },
+
+        "clicks_required.{}": {
+          "label": "Erforderliche Klicks",
+          "hint": "Die Anzahl der Klicks auf die Funktionsschaltfläche, die zur Bestätigung der Aktion nötig sind."
+        },
+
+        "separator.rules_informational.{}": {
+          "label": "Einschränkungsregeln",
+          "hint": "Verwalte die Regeln, die von der Einschränkungsfunktion geprüft werden"
+        },
+
+        "numeric_restrictions.{}": {
+          "label": "Numerische Bedingungen",
+          "hint": "Regeln, die numerische Bedingungen prüfen (z. B. Gesamtzahl an Gegenständen oder Coins), um Zielaktionen einzuschränken."
+        },
+
+        "string_restrictions.{}": {
+          "label": "Namensbedingungen",
+          "hint": "Regeln, die bestimmte Gegenstandsnamen oder -typen prüfen, um Zielaktionen einzuschränken."
+        },
+
+        "control.{}": {
+          "targets.{}": {
+            "label": "Funktionen",
+            "hint": "Die Funktionen, für die diese Regel aktiv ist."
+          },
+
+          "numeric.{}": {
+            "type.{}": {
+              "label": "Einschränkungstyp",
+              "hint": "Ob die Einschränkung auf den Gesamtwert in Coins oder auf die Gegenstandsmenge reagiert."
+            },
+            "threshold.{}": {
+              "label": "Schwellenwert",
+              "hint": "Der Wert, ab dem die Einschränkung ausgelöst wird."
+            }
+          },
+
+          "name.{}": {
+            "value.{}": {
+              "label": "Gegenstandsname",
+              "hint": "Der Gegenstandsname, der die Einschränkung auslöst, wenn er in der Verkaufsaktion vorkommt."
+            }
+          }
+        }
+      }
+    },
+
+    "overlays.{}": {
+      "category.label": "Overlays",
+      "category.hint": "Konfigurationen für die Overlays, die von der Mod erstellt werden",
+
+      "separator.price_charts.label": "Preisdiagramme",
+      "price_charts.{}": {
+        "label": "Preisdiagramme",
+        "hint": "Fügt Tooltips von Bazaar-Gegenständen einen Link für den schnellen Zugriff auf Marktpreisdiagramme hinzu.",
+        "show_outside_bazaar.{}": {
+          "label": "Außerhalb des Bazaars anzeigen",
+          "hint": "Ob Preisdiagramme in Tooltips angezeigt werden, wenn du dich außerhalb eines Bazaar-Menüs befindest."
+        }
+      },
+
+      "separator.bazaar_limits_visualizer.label": "Bazaar-Limits",
+      "bazaar_limits_visualizer.{}": {
+        "label": "Bazaar-Limits",
+        "hint": [
+          "Zeigt den Status deines täglichen Bazaar-Limits in Bazaar-Menüs an.\n\nProfile sind auf ",
+          {
+            "text": "15.000.000.000,00 Coins",
+            "color": "gold",
+            "hover_event": {
+              "action": "show_text",
+              "value": [
+                { "text": "Tägliches Bazaar-Limit\n", "color": "gold", "bold": true },
+                { "text": "Wird um Mitternacht UTC zurückgesetzt.\n", "color": "gray" },
+                { "text": "Gilt pro Profil, nicht pro Account.", "color": "dark_gray", "italic": true }
+              ]
+            }
+          },
+          " an handelbaren Orders/Angeboten pro Tag begrenzt."
+        ],
+        "reset_limits.label": "Tägliche Order-Limits",
+        "reset_limits.runnable": "Zurücksetzen"
+      }
+    },
+
+    "notifications.{}": {
+      "category.label": "Benachrichtigungen",
+      "category.hint": "Konfigurationen für die Benachrichtigungen, die von der Mod gesendet werden",
+
+      "separator.order_notifications.label": "Order-Benachrichtigungen",
+      "order_notifications.{}": {
+        "label": "Order-Benachrichtigungen",
+        "hint": "Aktiviert Benachrichtigungen zum Status deiner Bazaar-Orders.",
+        "outbid.{}": {
+          "label": "Order überboten",
+          "hint": "Konfiguriert die Benachrichtigung, die angezeigt wird, wenn deine Order überboten wird."
+        },
+        "filled.{}": {
+          "label": "Order erfüllt",
+          "hint": "Konfiguriert die Benachrichtigung, die angezeigt wird, wenn deine Order erfüllt wird."
+        }
+      },
+
+      "notification.{}": {
+        "enabled.{}": {
+          "label": "Aktiviert",
+          "hint": "Ob die Benachrichtigung erzeugt wird."
+        },
+        "auto_open_bazaar.label": "Bazaar automatisch öffnen",
+        "emit_chat_message.label": "Chat-Nachricht senden",
+        "emit_client_sound.label": "Client-Sound abspielen"
+      }
+    },
+
+    "advanced.{}": {
+      "category.label": "Erweiterte Einstellungen",
+      "category.hint": "Erweiterte Konfigurationen für Routinen & Funktionen der Mod",
+      "auto_update.{}": {
+        "label": "Automatisches Update",
+        "hint": "Aktualisiert die Mod automatisch, wenn ein Update gefunden wird."
+      }
+    },
+
+    "developer.{}": {
+      "category.label": "Entwickler-Konfiguration",
+      "category.hint": "Entwicklerkonfigurationen & zuschaltbare Werkzeuge der Mod",
+      "enabled.{}": {
+        "label": "Aktiviert",
+        "hint": "Globaler Schalter für alle Entwicklerfunktionen und -werkzeuge."
+      },
+      "disable_error_notifications.label": "Fehlerbenachrichtigungen deaktivieren",
+      "debug_messages.{}": {
+        "label": "Debug-Nachrichten",
+        "hint": "Konfiguriert Debug-Nachrichten im Chat zu Routinen und Zustand der Mod"
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/bazaarutils/lang/fr_fr.json5
+++ b/src/main/resources/assets/bazaarutils/lang/fr_fr.json5
@@ -1,0 +1,429 @@
+{
+  "owo:extended_lang": true,
+
+  "bazaarutils.ref.{}": {
+    "instant_sell": [{
+      "text": "Instant Sell",
+      "color": "green"
+    }],
+
+    "booster_cookie": [{
+      "text": "Booster Cookie",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Booster Cookie\n", "color": "light_purple", "bold": true },
+          { "text": "Donne accès à l'API des ordres du Bazaar\nainsi qu'à d'autres avantages SkyBlock.\n\n", "color": "gray" },
+          { "text": "↗ Cliquez pour ouvrir le wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Booster_Cookie"
+      }
+    }],
+
+    "bazaar_flipper": [{
+      "text": "Bazaar Flipper",
+      "color": "gold",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Bazaar Flipper\n", "color": "gold", "bold": true },
+          { "text": "Une amélioration de compte qui réduit la taxe\net augmente votre limite d'ordres actifs.\n\n", "color": "gray" },
+          { "text": "↗ Cliquez pour ouvrir le wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Bazaar_Flipper"
+      }
+    }],
+
+    "elizabeth": [{
+      "text": "Elizabeth",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Elizabeth\n", "color": "light_purple", "bold": true },
+          { "text": "PNJ au ", "color": "gray" },
+          { "text": "Community Center", "color": "gray" },
+          { "text": " dans le SkyBlock Hub.\n", "color": "gray" },
+          { "text": "Vend des améliorations de compte contre des Gems.\n\n", "color": "gray" },
+          { "text": "↗ Cliquez pour ouvrir le wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Elizabeth"
+      }
+    }],
+
+    "community_center": [{ "text": "Community Center", "color": "aqua" }],
+    "skyblock_hub": [{ "text": "SkyBlock Hub", "color": "aqua" }]
+  },
+
+  "mod.bazaarutils": "Bazaar Utils",
+  "key.category.minecraft.bazaarutils": "Bazaar Utils",
+
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Rechercher...",
+      "select": "Sélectionner"
+    }
+  },
+
+  "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
+    "not_upgraded.label": "Non amélioré",
+    "first_tier.label": "Bazaar Flipper I",
+    "second_tier.label": "Bazaar Flipper II"
+  },
+
+  "bazaarutils.config.{}": {
+
+    "separator.introductory.label": "Bienvenue dans Bazaar Utils !",
+    "separator.introductory.hint": "Merci d'avoir installé Bazaar Utils ! Ce mod apporte des améliorations de confort pour le Bazaar d'Hypixel.",
+
+    "bazaar_flipper_account_upgrade.{}": {
+      "label": "Amélioration de compte Bazaar Flipper",
+      "hint": [
+        "Le niveau de votre amélioration de compte ", { "translate": "bazaarutils.ref.bazaar_flipper" },
+        ", qui est pris en compte dans le calcul de la taxe et dans vos limites d'ordres actuelles.",
+        "\nVotre niveau de Bazaar Flipper peut être amélioré en parlant à ",
+        { "translate": "bazaarutils.ref.elizabeth" }, " au ",
+        { "translate": "bazaarutils.ref.community_center" }, " dans le ",
+        { "translate": "bazaarutils.ref.skyblock_hub" }, "."
+      ]
+    },
+
+    "chat.{}": {
+      "category.label": "Chat",
+      "category.hint": "Réglages des fonctionnalités de chat du mod",
+
+      "separator.useless_bazaar_notifications_remover.label": "Notifications inutiles du Bazaar",
+      "useless_bazaar_notifications_remover.{}": {
+        "label": "Notifications inutiles du Bazaar",
+        "hint": "Supprime certains messages temporaires envoyés dans le chat lors des interactions avec le Bazaar afin de réduire l'encombrement.",
+        "excluded_notifications.{}": {
+          "label": "Notifications exclues",
+          "hint": "Une liste de messages et de notifications à bloquer dans le chat."
+        }
+      },
+
+      "separator.stash_messages_remover.label": "Messages de stash",
+      "stash_messages_remover.{}": {
+        "label": "Messages de stash",
+        "hint": "Supprime les messages du chat vous rappelant de récupérer les objets de votre stash."
+      }
+    },
+
+    "buttons.{}": {
+      "category.label": "Boutons",
+      "category.hint": "Réglages des boutons ajoutés et gérés par le mod",
+
+      "separator.mod_buttons.{}": {
+        "label": "Boutons du mod",
+        "hint": "Ajoute des boutons aux écrans d'inventaire pour accéder rapidement aux fonctionnalités du mod."
+      },
+
+      "open_settings.{}": {
+        "label": "Bouton des paramètres du mod",
+        "hint": "Ajoute un bouton dans certains menus pour accéder rapidement aux paramètres du mod."
+      },
+
+      "open_orders.{}": {
+        "label": "Bouton de la page des ordres",
+        "hint": [
+          "Ajoute un bouton dans certains menus pour accéder rapidement à la page de vos ordres.",
+          "\n\nNécessite un ", { "translate": "bazaarutils.ref.booster_cookie" }, " actif."
+        ]
+      },
+
+      "separator.container_buttons.{}": {
+        "label": "Boutons de conteneur",
+        "hint": "Ajoute des boutons d'aide à certaines interfaces de conteneur."
+      },
+
+      "cancel_order_and_search.{}": {
+        "label": "Bouton Annuler et rechercher",
+        "hint": "Ajoute un bouton aux pages d'ordres/d'offres non remplis pour annuler l'ordre et rechercher immédiatement l'objet à nouveau."
+      },
+
+      "button.{}": {
+        "widget.{}": {
+          "enabled.{}": {
+            "label": "Activé",
+            "hint": "Si le bouton sera activé."
+          },
+          "size.label": "Taille du bouton",
+          "spacing.label": "Espacement"
+        },
+        "container.{}": {
+          "enabled.{}": {
+            "label": "Activé",
+            "hint": "Si le bouton sera activé."
+          },
+          "item_id.{}": {
+            "label": "Objet",
+            "hint": "L'objet qui sera placé en tant que bouton."
+          },
+          "slot_index.{}": {
+            "label": "Numéro d'emplacement",
+            "hint": "L'emplacement du conteneur où le bouton sera placé."
+          },
+          "amount_strategy.{}": {
+            "label": "Stratégie de quantité",
+            "hint": "La stratégie utilisée pour calculer la quantité.\n\nMAX : Commandera la quantité maximale possible selon l'action (instantané, ordre).\nFIXED : Commandera la quantité que vous avez configurée ci-dessous."
+          },
+          "pricing_position.{}": {
+            "label": "Position tarifaire",
+            "hint": "La stratégie utilisée pour calculer le prix proposé par objet\n\nCOMPETITIVE : L'offre sera à +0,1 par rapport à la meilleure offre actuelle du marché\nMATCHED : L'offre sera égale à la meilleure offre actuelle du marché\nOUTBID : L'offre sera à -0,1 par rapport à la meilleure offre actuelle du marché"
+          },
+          "fixed_amount.{}": {
+            "label": "Quantité fixe",
+            "hint": "La quantité utilisée si FIXED est défini comme stratégie de quantité."
+          }
+        }
+      },
+
+      "bookmarks.{}": {
+        "category.label": "Favoris",
+
+        "separator.introductory.{}": {
+          "label": "Objets favoris",
+          "hint": "Les objets favoris vous permettent de rechercher rapidement des objets précis sur le Bazaar."
+        },
+
+        "open_bookmark.{}": {
+          "label": "Ouvrir le favori",
+          "hint": "Configure le bouton, dans certains menus, qui recherche rapidement l'objet mis en favori."
+        },
+
+        "toggle_bookmark.{}": {
+          "label": "Mettre l'objet en favori",
+          "hint": "Ajoute un bouton aux pages d'objets pour ajouter ou retirer l'objet de vos favoris."
+        },
+
+        "reset_bookmarks.label": "Favoris enregistrés",
+        "reset_bookmarks.runnable": "Réinitialiser"
+      },
+
+      "helpers.{}": {
+        "category.label": "Aides à la saisie",
+
+        "separator.buy_related.{}": {
+          "label": "Aides à l'achat",
+          "hint": "Aides qui apparaissent lors des achats sur le Bazaar. Configurez des boutons pour remplir automatiquement les quantités ou les prix lors d'un achat instantané ou d'un ordre d'achat."
+        },
+
+        "instant_buy_amount.label": "Quantité d'achat instantané",
+        "buy_order_amount.label": "Quantité de l'ordre d'achat",
+        "buy_order_price.label": "Prix de l'ordre d'achat",
+
+        "separator.sell_related.{}": {
+          "label": "Aides à la vente",
+          "hint": "Aides qui apparaissent lors des ventes sur le Bazaar. Configurez des boutons pour remplir automatiquement les quantités ou les prix lors d'une offre de vente ou d'un flip d'ordre."
+        },
+
+        "flip_order_price.label": "Prix du flip d'ordre",
+        "sell_offer_amount.label": "Quantité de l'offre de vente",
+        "sell_offer_price.label": "Prix de l'offre de vente"
+      }
+    },
+
+    "inventory.{}": {
+      "category.label": "Inventaire",
+      "category.hint": "Réglages des fonctionnalités d'inventaire du mod",
+
+      "separator.instant_sell_highlight.label": "Surbrillance Instant Sell",
+      "instant_sell_highlight.{}": {
+        "label": "Surbrillance Instant Sell",
+        "hint": [
+          "Met en surbrillance les objets de votre inventaire qui seraient vendus par le bouton Instant Sell."
+        ],
+        "color.label": "Couleur de surbrillance"
+      },
+
+      "separator.order_status_highlight.label": "Surbrillance du statut des ordres",
+      "order_status_highlight.{}": {
+        "label": "Surbrillance du statut des ordres",
+        "hint": "Met en évidence le statut de vos ordres du Bazaar en colorant les objets avec des couleurs représentatives.",
+
+        "competitive_color.{}": {
+          "label": "Couleur « meilleure offre »",
+          "hint": "La couleur de surbrillance des ordres qui sont actuellement la meilleure offre du marché."
+        },
+
+        "matched_color.{}": {
+          "label": "Couleur « prix égalé »",
+          "hint": "La couleur de surbrillance des ordres qui correspondent au prix actuel du marché."
+        },
+
+        "outbid_color.{}": {
+          "label": "Couleur « surenchéri »",
+          "hint": "La couleur de surbrillance des ordres qui ont été surenchéris."
+        }
+      },
+
+      "restrictions.{}": {
+        "separator.introductory.{}": {
+          "label": "Restrictions d'inventaire"
+        },
+
+        "category.label": "Restrictions d'inventaire",
+
+        "enabled.{}": {
+          "label": "Restrictions d'inventaire",
+          "hint": "Verrouille certains boutons du Bazaar selon des critères d'inventaire ou d'action afin d'éviter les opérations de marché accidentelles."
+        },
+
+        "features.{}": {
+          "label": "Boutons restreints",
+          "hint": "Les boutons d'inventaire pour lesquels les restrictions sont activées.",
+
+          "target.{}": {
+            "instant_sell.label": "Instant Sell",
+            "sell_sacks.label": "Sell Sacks"
+          }
+        },
+
+        "clicks_required.{}": {
+          "label": "Clics requis",
+          "hint": "Le nombre de clics requis sur le bouton de la fonctionnalité pour confirmer l'action."
+        },
+
+        "separator.rules_informational.{}": {
+          "label": "Règles de restriction",
+          "hint": "Gérez les règles vérifiées par la fonctionnalité de restrictions"
+        },
+
+        "numeric_restrictions.{}": {
+          "label": "Prédicats numériques",
+          "hint": "Règles vérifiant des conditions numériques (par ex. le total d'objets ou de coins) pour restreindre les actions ciblées."
+        },
+
+        "string_restrictions.{}": {
+          "label": "Prédicats de nom",
+          "hint": "Règles vérifiant des noms ou types d'objets précis pour restreindre les actions ciblées."
+        },
+
+        "control.{}": {
+          "targets.{}": {
+            "label": "Fonctionnalités",
+            "hint": "Les fonctionnalités pour lesquelles cette règle est active."
+          },
+
+          "numeric.{}": {
+            "type.{}": {
+              "label": "Type de restriction",
+              "hint": "Si la restriction se déclenche sur la valeur totale en coins ou sur la quantité d'objets."
+            },
+            "threshold.{}": {
+              "label": "Seuil",
+              "hint": "La valeur au-delà de laquelle la restriction se déclenchera."
+            }
+          },
+
+          "name.{}": {
+            "value.{}": {
+              "label": "Nom de l'objet",
+              "hint": "Le nom d'objet qui déclenchera la restriction s'il est présent dans l'action de vente."
+            }
+          }
+        }
+      }
+    },
+
+    "overlays.{}": {
+      "category.label": "Superpositions",
+      "category.hint": "Réglages des superpositions créées par le mod",
+
+      "separator.price_charts.label": "Graphiques de prix",
+      "price_charts.{}": {
+        "label": "Graphiques de prix",
+        "hint": "Ajoute un lien dans les infobulles des objets du Bazaar pour accéder rapidement aux graphiques de prix du marché.",
+        "show_outside_bazaar.{}": {
+          "label": "Afficher en dehors du Bazaar",
+          "hint": "Si les graphiques de prix doivent apparaître dans les infobulles en dehors d'un menu du Bazaar."
+        }
+      },
+
+      "separator.bazaar_limits_visualizer.label": "Limites du Bazaar",
+      "bazaar_limits_visualizer.{}": {
+        "label": "Limites du Bazaar",
+        "hint": [
+          "Affiche l'état de votre limite quotidienne du Bazaar sur les écrans du Bazaar.\n\nLes profils sont limités à ",
+          {
+            "text": "15 000 000 000,00 coins",
+            "color": "gold",
+            "hover_event": {
+              "action": "show_text",
+              "value": [
+                { "text": "Limite quotidienne du Bazaar\n", "color": "gold", "bold": true },
+                { "text": "Réinitialisée à minuit UTC.\n", "color": "gray" },
+                { "text": "S'applique par profil, et non par compte.", "color": "dark_gray", "italic": true }
+              ]
+            }
+          },
+          " d'ordres/offres échangeables par jour."
+        ],
+        "reset_limits.label": "Limites d'ordres quotidiennes",
+        "reset_limits.runnable": "Réinitialiser"
+      }
+    },
+
+    "notifications.{}": {
+      "category.label": "Notifications",
+      "category.hint": "Réglages des notifications envoyées par le mod",
+
+      "separator.order_notifications.label": "Notifications d'ordres",
+      "order_notifications.{}": {
+        "label": "Notifications d'ordres",
+        "hint": "Active les notifications liées au statut de vos ordres du Bazaar.",
+        "outbid.{}": {
+          "label": "Ordre surenchéri",
+          "hint": "Configure la notification affichée lorsque votre ordre est surenchéri."
+        },
+        "filled.{}": {
+          "label": "Ordre rempli",
+          "hint": "Configure la notification affichée lorsque votre ordre est rempli."
+        }
+      },
+
+      "notification.{}": {
+        "enabled.{}": {
+          "label": "Activé",
+          "hint": "Si la notification sera produite."
+        },
+        "auto_open_bazaar.label": "Ouvrir le Bazaar automatiquement",
+        "emit_chat_message.label": "Envoyer un message dans le chat",
+        "emit_client_sound.label": "Jouer un son côté client"
+      }
+    },
+
+    "advanced.{}": {
+      "category.label": "Paramètres avancés",
+      "category.hint": "Réglages avancés des routines et fonctionnalités du mod",
+      "auto_update.{}": {
+        "label": "Mise à jour automatique",
+        "hint": "Met automatiquement le mod à jour lorsqu'une mise à jour est trouvée."
+      }
+    },
+
+    "developer.{}": {
+      "category.label": "Configuration développeur",
+      "category.hint": "Réglages développeur et outils activables du mod",
+      "enabled.{}": {
+        "label": "Activé",
+        "hint": "Interrupteur global pour toutes les fonctionnalités et utilitaires de développement."
+      },
+      "disable_error_notifications.label": "Désactiver les notifications d'erreur",
+      "debug_messages.{}": {
+        "label": "Messages de débogage",
+        "hint": "Configure les messages de débogage envoyés dans le chat concernant les routines et l'état du mod"
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/bazaarutils/lang/pl_pl.json5
+++ b/src/main/resources/assets/bazaarutils/lang/pl_pl.json5
@@ -1,0 +1,429 @@
+{
+  "owo:extended_lang": true,
+
+  "bazaarutils.ref.{}": {
+    "instant_sell": [{
+      "text": "Instant Sell",
+      "color": "green"
+    }],
+
+    "booster_cookie": [{
+      "text": "Booster Cookie",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Booster Cookie\n", "color": "light_purple", "bold": true },
+          { "text": "Daje dostęp do API zleceń Bazaaru\noraz innych bonusów SkyBlocka.\n\n", "color": "gray" },
+          { "text": "↗ Kliknij, aby otworzyć wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Booster_Cookie"
+      }
+    }],
+
+    "bazaar_flipper": [{
+      "text": "Bazaar Flipper",
+      "color": "gold",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Bazaar Flipper\n", "color": "gold", "bold": true },
+          { "text": "Ulepszenie konta, które zmniejsza podatek\ni zwiększa limit aktywnych zleceń.\n\n", "color": "gray" },
+          { "text": "↗ Kliknij, aby otworzyć wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Bazaar_Flipper"
+      }
+    }],
+
+    "elizabeth": [{
+      "text": "Elizabeth",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Elizabeth\n", "color": "light_purple", "bold": true },
+          { "text": "NPC w ", "color": "gray" },
+          { "text": "Community Center", "color": "gray" },
+          { "text": " na SkyBlock Hubie.\n", "color": "gray" },
+          { "text": "Sprzedaje ulepszenia konta za Gemy.\n\n", "color": "gray" },
+          { "text": "↗ Kliknij, aby otworzyć wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Elizabeth"
+      }
+    }],
+
+    "community_center": [{ "text": "Community Center", "color": "aqua" }],
+    "skyblock_hub": [{ "text": "SkyBlock Hub", "color": "aqua" }]
+  },
+
+  "mod.bazaarutils": "Bazaar Utils",
+  "key.category.minecraft.bazaarutils": "Bazaar Utils",
+
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Szukaj...",
+      "select": "Wybierz"
+    }
+  },
+
+  "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
+    "not_upgraded.label": "Brak ulepszenia",
+    "first_tier.label": "Bazaar Flipper I",
+    "second_tier.label": "Bazaar Flipper II"
+  },
+
+  "bazaarutils.config.{}": {
+
+    "separator.introductory.label": "Witaj w Bazaar Utils!",
+    "separator.introductory.hint": "Dziękujemy za zainstalowanie Bazaar Utils! Ten mod dodaje udogodnienia dla Bazaaru na Hypixelu.",
+
+    "bazaar_flipper_account_upgrade.{}": {
+      "label": "Ulepszenie konta Bazaar Flipper",
+      "hint": [
+        "Poziom twojego ulepszenia konta ", { "translate": "bazaarutils.ref.bazaar_flipper" },
+        ", który jest uwzględniany przy obliczaniu podatku i aktualnych limitów zleceń.",
+        "\nPoziom Bazaar Flippera możesz podnieść, rozmawiając z ",
+        { "translate": "bazaarutils.ref.elizabeth" }, " w ",
+        { "translate": "bazaarutils.ref.community_center" }, " na ",
+        { "translate": "bazaarutils.ref.skyblock_hub" }, "."
+      ]
+    },
+
+    "chat.{}": {
+      "category.label": "Czat",
+      "category.hint": "Ustawienia funkcji czatu w tym modzie",
+
+      "separator.useless_bazaar_notifications_remover.label": "Zbędne powiadomienia Bazaaru",
+      "useless_bazaar_notifications_remover.{}": {
+        "label": "Zbędne powiadomienia Bazaaru",
+        "hint": "Usuwa wybrane tymczasowe wiadomości wysyłane na czat podczas korzystania z Bazaaru, aby ograniczyć bałagan.",
+        "excluded_notifications.{}": {
+          "label": "Wykluczone powiadomienia",
+          "hint": "Lista wiadomości i powiadomień blokowanych na czacie."
+        }
+      },
+
+      "separator.stash_messages_remover.label": "Wiadomości o schowku",
+      "stash_messages_remover.{}": {
+        "label": "Wiadomości o schowku",
+        "hint": "Usuwa wiadomości z czatu przypominające o odebraniu przedmiotów ze schowka (stash)."
+      }
+    },
+
+    "buttons.{}": {
+      "category.label": "Przyciski",
+      "category.hint": "Ustawienia przycisków dodawanych i obsługiwanych przez mod",
+
+      "separator.mod_buttons.{}": {
+        "label": "Przyciski moda",
+        "hint": "Dodaje przyciski do ekranów ekwipunku dla szybkiego dostępu do funkcji moda."
+      },
+
+      "open_settings.{}": {
+        "label": "Przycisk ustawień moda",
+        "hint": "Dodaje do wybranych menu przycisk szybkiego dostępu do ustawień moda."
+      },
+
+      "open_orders.{}": {
+        "label": "Przycisk strony zleceń",
+        "hint": [
+          "Dodaje do wybranych menu przycisk szybkiego dostępu do strony twoich zleceń.",
+          "\n\nWymaga aktywnego ", { "translate": "bazaarutils.ref.booster_cookie" }, "."
+        ]
+      },
+
+      "separator.container_buttons.{}": {
+        "label": "Przyciski w kontenerach",
+        "hint": "Dodaje pomocnicze przyciski do wybranych interfejsów kontenerów."
+      },
+
+      "cancel_order_and_search.{}": {
+        "label": "Przycisk Anuluj i szukaj",
+        "hint": "Dodaje na stronach niezrealizowanych zleceń/ofert przycisk, który anuluje zlecenie i od razu wyszukuje ten przedmiot ponownie."
+      },
+
+      "button.{}": {
+        "widget.{}": {
+          "enabled.{}": {
+            "label": "Włączony",
+            "hint": "Czy przycisk będzie włączony."
+          },
+          "size.label": "Rozmiar przycisku",
+          "spacing.label": "Odstęp"
+        },
+        "container.{}": {
+          "enabled.{}": {
+            "label": "Włączony",
+            "hint": "Czy przycisk będzie włączony."
+          },
+          "item_id.{}": {
+            "label": "Przedmiot",
+            "hint": "Przedmiot, który zostanie umieszczony jako przycisk."
+          },
+          "slot_index.{}": {
+            "label": "Numer slotu",
+            "hint": "Slot kontenera, w którym zostanie umieszczony przycisk."
+          },
+          "amount_strategy.{}": {
+            "label": "Strategia ilości",
+            "hint": "Strategia obliczania wartości ilości.\n\nMAX: Zleci maksymalną ilość, jaką możesz zlecić przy danej akcji (instant, zlecenie).\nFIXED: Zleci ilość ustawioną poniżej."
+          },
+          "pricing_position.{}": {
+            "label": "Pozycja cenowa",
+            "hint": "Strategia obliczania ceny oferowanej za przedmiot\n\nCOMPETITIVE: Oferta będzie o +0,1 wyższa od najlepszej obecnej oferty na rynku\nMATCHED: Oferta będzie równa najlepszej obecnej ofercie na rynku\nOUTBID: Oferta będzie o -0,1 niższa od najlepszej obecnej oferty na rynku"
+          },
+          "fixed_amount.{}": {
+            "label": "Stała ilość",
+            "hint": "Ilość, która zostanie użyta, jeśli jako strategię ilości ustawiono FIXED."
+          }
+        }
+      },
+
+      "bookmarks.{}": {
+        "category.label": "Zakładki",
+
+        "separator.introductory.{}": {
+          "label": "Zakładki przedmiotów",
+          "hint": "Zakładki przedmiotów pozwalają szybko wyszukiwać wybrane przedmioty na Bazaarze."
+        },
+
+        "open_bookmark.{}": {
+          "label": "Otwórz zakładkę",
+          "hint": "Konfiguruje przycisk w wybranych menu, który szybko wyszukuje przedmiot z zakładki."
+        },
+
+        "toggle_bookmark.{}": {
+          "label": "Dodaj do zakładek",
+          "hint": "Dodaje na stronach przedmiotów przycisk przełączający, czy przedmiot jest w zakładkach dla szybkiego dostępu."
+        },
+
+        "reset_bookmarks.label": "Zapisane zakładki",
+        "reset_bookmarks.runnable": "Zresetuj"
+      },
+
+      "helpers.{}": {
+        "category.label": "Pomocniki wpisywania",
+
+        "separator.buy_related.{}": {
+          "label": "Pomocniki kupna",
+          "hint": "Pomocniki pojawiające się podczas kupowania na Bazaarze. Skonfiguruj przyciski automatycznie uzupełniające ilości lub ceny przy natychmiastowym kupnie i składaniu zleceń kupna."
+        },
+
+        "instant_buy_amount.label": "Ilość natychmiastowego kupna",
+        "buy_order_amount.label": "Ilość zlecenia kupna",
+        "buy_order_price.label": "Cena zlecenia kupna",
+
+        "separator.sell_related.{}": {
+          "label": "Pomocniki sprzedaży",
+          "hint": "Pomocniki pojawiające się podczas sprzedawania na Bazaarze. Skonfiguruj przyciski automatycznie uzupełniające ilości lub ceny przy składaniu ofert sprzedaży i flipowaniu zleceń."
+        },
+
+        "flip_order_price.label": "Cena flipowania zlecenia",
+        "sell_offer_amount.label": "Ilość oferty sprzedaży",
+        "sell_offer_price.label": "Cena oferty sprzedaży"
+      }
+    },
+
+    "inventory.{}": {
+      "category.label": "Ekwipunek",
+      "category.hint": "Ustawienia funkcji ekwipunku w tym modzie",
+
+      "separator.instant_sell_highlight.label": "Podświetlenie Instant Sell",
+      "instant_sell_highlight.{}": {
+        "label": "Podświetlenie Instant Sell",
+        "hint": [
+          "Podświetla w ekwipunku przedmioty, które zostałyby sprzedane przyciskiem Instant Sell."
+        ],
+        "color.label": "Kolor podświetlenia"
+      },
+
+      "separator.order_status_highlight.label": "Podświetlenie statusu zleceń",
+      "order_status_highlight.{}": {
+        "label": "Podświetlenie statusu zleceń",
+        "hint": "Pokazuje status twoich zleceń na Bazaarze, kolorując przedmioty odpowiednimi barwami.",
+
+        "competitive_color.{}": {
+          "label": "Kolor najlepszej oferty",
+          "hint": "Kolor podświetlenia zleceń, które są obecnie najlepszą ofertą na rynku."
+        },
+
+        "matched_color.{}": {
+          "label": "Kolor oferty równej rynkowi",
+          "hint": "Kolor podświetlenia zleceń zgodnych z obecną ceną rynkową."
+        },
+
+        "outbid_color.{}": {
+          "label": "Kolor przebitej oferty",
+          "hint": "Kolor podświetlenia zleceń, które zostały przebite."
+        }
+      },
+
+      "restrictions.{}": {
+        "separator.introductory.{}": {
+          "label": "Ograniczenia ekwipunku"
+        },
+
+        "category.label": "Ograniczenia ekwipunku",
+
+        "enabled.{}": {
+          "label": "Ograniczenia ekwipunku",
+          "hint": "Blokuje wybrane przyciski Bazaaru na podstawie kryteriów ekwipunku lub akcji, aby zapobiec przypadkowym operacjom rynkowym."
+        },
+
+        "features.{}": {
+          "label": "Ograniczone przyciski",
+          "hint": "Przyciski ekwipunku, dla których ograniczenia są włączone.",
+
+          "target.{}": {
+            "instant_sell.label": "Instant Sell",
+            "sell_sacks.label": "Sell Sacks"
+          }
+        },
+
+        "clicks_required.{}": {
+          "label": "Wymagane kliknięcia",
+          "hint": "Liczba kliknięć przycisku funkcji wymagana do potwierdzenia akcji."
+        },
+
+        "separator.rules_informational.{}": {
+          "label": "Reguły ograniczeń",
+          "hint": "Zarządzaj regułami sprawdzanymi przez funkcję ograniczeń"
+        },
+
+        "numeric_restrictions.{}": {
+          "label": "Warunki liczbowe",
+          "hint": "Reguły sprawdzające warunki liczbowe (np. łączną liczbę przedmiotów lub monet), aby ograniczyć wybrane akcje."
+        },
+
+        "string_restrictions.{}": {
+          "label": "Warunki nazw",
+          "hint": "Reguły sprawdzające konkretne nazwy lub typy przedmiotów, aby ograniczyć wybrane akcje."
+        },
+
+        "control.{}": {
+          "targets.{}": {
+            "label": "Funkcje",
+            "hint": "Funkcje, dla których ta reguła jest aktywna."
+          },
+
+          "numeric.{}": {
+            "type.{}": {
+              "label": "Typ ograniczenia",
+              "hint": "Czy ograniczenie reaguje na łączną wartość w monetach, czy na liczbę przedmiotów."
+            },
+            "threshold.{}": {
+              "label": "Próg",
+              "hint": "Wartość, powyżej której ograniczenie zostanie uruchomione."
+            }
+          },
+
+          "name.{}": {
+            "value.{}": {
+              "label": "Nazwa przedmiotu",
+              "hint": "Nazwa przedmiotu, która uruchomi ograniczenie, jeśli wystąpi w akcji sprzedaży."
+            }
+          }
+        }
+      }
+    },
+
+    "overlays.{}": {
+      "category.label": "Nakładki",
+      "category.hint": "Ustawienia nakładek tworzonych przez mod",
+
+      "separator.price_charts.label": "Wykresy cen",
+      "price_charts.{}": {
+        "label": "Wykresy cen",
+        "hint": "Dodaje do podpowiedzi przedmiotów Bazaaru odnośnik do szybkiego podglądu wykresów cen rynkowych.",
+        "show_outside_bazaar.{}": {
+          "label": "Pokazuj poza Bazaarem",
+          "hint": "Czy wykresy cen mają być pokazywane w podpowiedziach poza menu Bazaaru."
+        }
+      },
+
+      "separator.bazaar_limits_visualizer.label": "Limity Bazaaru",
+      "bazaar_limits_visualizer.{}": {
+        "label": "Limity Bazaaru",
+        "hint": [
+          "Wyświetla status twojego dziennego limitu Bazaaru na ekranach Bazaaru.\n\nProfile są ograniczone do ",
+          {
+            "text": "15 000 000 000,00 monet",
+            "color": "gold",
+            "hover_event": {
+              "action": "show_text",
+              "value": [
+                { "text": "Dzienny limit Bazaaru\n", "color": "gold", "bold": true },
+                { "text": "Resetuje się o północy UTC.\n", "color": "gray" },
+                { "text": "Obowiązuje na profil, a nie na konto.", "color": "dark_gray", "italic": true }
+              ]
+            }
+          },
+          " w zleceniach/ofertach handlowych dziennie."
+        ],
+        "reset_limits.label": "Dzienne limity zleceń",
+        "reset_limits.runnable": "Zresetuj"
+      }
+    },
+
+    "notifications.{}": {
+      "category.label": "Powiadomienia",
+      "category.hint": "Ustawienia powiadomień wysyłanych przez mod",
+
+      "separator.order_notifications.label": "Powiadomienia o zleceniach",
+      "order_notifications.{}": {
+        "label": "Powiadomienia o zleceniach",
+        "hint": "Włącza powiadomienia dotyczące statusu twoich zleceń na Bazaarze.",
+        "outbid.{}": {
+          "label": "Zlecenie przebite",
+          "hint": "Konfiguruje powiadomienie pokazywane, gdy twoje zlecenie zostanie przebite."
+        },
+        "filled.{}": {
+          "label": "Zlecenie zrealizowane",
+          "hint": "Konfiguruje powiadomienie pokazywane, gdy twoje zlecenie zostanie zrealizowane."
+        }
+      },
+
+      "notification.{}": {
+        "enabled.{}": {
+          "label": "Włączone",
+          "hint": "Czy powiadomienie będzie wysyłane."
+        },
+        "auto_open_bazaar.label": "Automatycznie otwórz Bazaar",
+        "emit_chat_message.label": "Wyślij wiadomość na czat",
+        "emit_client_sound.label": "Odtwórz dźwięk"
+      }
+    },
+
+    "advanced.{}": {
+      "category.label": "Ustawienia zaawansowane",
+      "category.hint": "Zaawansowane ustawienia procedur i funkcji moda",
+      "auto_update.{}": {
+        "label": "Automatyczna aktualizacja",
+        "hint": "Automatycznie aktualizuje mod, gdy zostanie znaleziona nowa wersja."
+      }
+    },
+
+    "developer.{}": {
+      "category.label": "Ustawienia dewelopera",
+      "category.hint": "Ustawienia deweloperskie i przełączalne narzędzia moda",
+      "enabled.{}": {
+        "label": "Włączone",
+        "hint": "Główny przełącznik wszystkich funkcji i narzędzi deweloperskich."
+      },
+      "disable_error_notifications.label": "Wyłącz powiadomienia o błędach",
+      "debug_messages.{}": {
+        "label": "Wiadomości debugowania",
+        "hint": "Konfiguruje wiadomości debugowania wysyłane na czat, dotyczące procedur i stanu moda"
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/bazaarutils/lang/ru_ru.json5
+++ b/src/main/resources/assets/bazaarutils/lang/ru_ru.json5
@@ -1,0 +1,429 @@
+{
+  "owo:extended_lang": true,
+
+  "bazaarutils.ref.{}": {
+    "instant_sell": [{
+      "text": "Instant Sell",
+      "color": "green"
+    }],
+
+    "booster_cookie": [{
+      "text": "Booster Cookie",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Booster Cookie\n", "color": "light_purple", "bold": true },
+          { "text": "Даёт доступ к API ордеров Bazaar\nи другим привилегиям SkyBlock.\n\n", "color": "gray" },
+          { "text": "↗ Нажмите, чтобы открыть вики", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Booster_Cookie"
+      }
+    }],
+
+    "bazaar_flipper": [{
+      "text": "Bazaar Flipper",
+      "color": "gold",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Bazaar Flipper\n", "color": "gold", "bold": true },
+          { "text": "Улучшение аккаунта, которое снижает налог\nи повышает лимит активных ордеров.\n\n", "color": "gray" },
+          { "text": "↗ Нажмите, чтобы открыть вики", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Bazaar_Flipper"
+      }
+    }],
+
+    "elizabeth": [{
+      "text": "Elizabeth",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Elizabeth\n", "color": "light_purple", "bold": true },
+          { "text": "NPC в ", "color": "gray" },
+          { "text": "Community Center", "color": "gray" },
+          { "text": " в SkyBlock Hub.\n", "color": "gray" },
+          { "text": "Продаёт улучшения аккаунта за Gems.\n\n", "color": "gray" },
+          { "text": "↗ Нажмите, чтобы открыть вики", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Elizabeth"
+      }
+    }],
+
+    "community_center": [{ "text": "Community Center", "color": "aqua" }],
+    "skyblock_hub": [{ "text": "SkyBlock Hub", "color": "aqua" }]
+  },
+
+  "mod.bazaarutils": "Bazaar Utils",
+  "key.category.minecraft.bazaarutils": "Bazaar Utils",
+
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "Поиск...",
+      "select": "Выбрать"
+    }
+  },
+
+  "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
+    "not_upgraded.label": "Не улучшено",
+    "first_tier.label": "Bazaar Flipper I",
+    "second_tier.label": "Bazaar Flipper II"
+  },
+
+  "bazaarutils.config.{}": {
+
+    "separator.introductory.label": "Добро пожаловать в Bazaar Utils!",
+    "separator.introductory.hint": "Спасибо за установку Bazaar Utils! Этот мод добавляет удобные функции для Bazaar на Hypixel.",
+
+    "bazaar_flipper_account_upgrade.{}": {
+      "label": "Улучшение аккаунта Bazaar Flipper",
+      "hint": [
+        "Уровень вашего улучшения аккаунта ", { "translate": "bazaarutils.ref.bazaar_flipper" },
+        ", который учитывается при расчёте налога и текущих лимитов ордеров.",
+        "\nПовысить уровень Bazaar Flipper можно, поговорив с ",
+        { "translate": "bazaarutils.ref.elizabeth" }, " в ",
+        { "translate": "bazaarutils.ref.community_center" }, " в ",
+        { "translate": "bazaarutils.ref.skyblock_hub" }, "."
+      ]
+    },
+
+    "chat.{}": {
+      "category.label": "Чат",
+      "category.hint": "Настройки чат-функций мода",
+
+      "separator.useless_bazaar_notifications_remover.label": "Бесполезные уведомления Bazaar",
+      "useless_bazaar_notifications_remover.{}": {
+        "label": "Бесполезные уведомления Bazaar",
+        "hint": "Удаляет отдельные временные сообщения, отправляемые в чат при взаимодействии с Bazaar, чтобы уменьшить захламление.",
+        "excluded_notifications.{}": {
+          "label": "Исключённые уведомления",
+          "hint": "Список сообщений и уведомлений, которые будут блокироваться в чате."
+        }
+      },
+
+      "separator.stash_messages_remover.label": "Сообщения о стеше",
+      "stash_messages_remover.{}": {
+        "label": "Сообщения о стеше",
+        "hint": "Удаляет сообщения в чате, напоминающие забрать предметы из стеша."
+      }
+    },
+
+    "buttons.{}": {
+      "category.label": "Кнопки",
+      "category.hint": "Настройки кнопок, добавляемых и обрабатываемых модом",
+
+      "separator.mod_buttons.{}": {
+        "label": "Кнопки мода",
+        "hint": "Добавляет кнопки на экраны инвентаря для быстрого доступа к функциям мода."
+      },
+
+      "open_settings.{}": {
+        "label": "Кнопка настроек мода",
+        "hint": "Добавляет в выбранные меню кнопку для быстрого доступа к настройкам мода."
+      },
+
+      "open_orders.{}": {
+        "label": "Кнопка страницы ордеров",
+        "hint": [
+          "Добавляет в выбранные меню кнопку для быстрого доступа к странице ваших ордеров.",
+          "\n\nТребуется активный ", { "translate": "bazaarutils.ref.booster_cookie" }, "."
+        ]
+      },
+
+      "separator.container_buttons.{}": {
+        "label": "Кнопки в контейнерах",
+        "hint": "Добавляет вспомогательные кнопки в отдельные интерфейсы контейнеров."
+      },
+
+      "cancel_order_and_search.{}": {
+        "label": "Кнопка «Отменить и найти»",
+        "hint": "Добавляет на страницы незавершённых ордеров/предложений кнопку, которая отменяет ордер и сразу же снова ищет этот предмет."
+      },
+
+      "button.{}": {
+        "widget.{}": {
+          "enabled.{}": {
+            "label": "Включено",
+            "hint": "Будет ли кнопка включена."
+          },
+          "size.label": "Размер кнопки",
+          "spacing.label": "Отступ"
+        },
+        "container.{}": {
+          "enabled.{}": {
+            "label": "Включено",
+            "hint": "Будет ли кнопка включена."
+          },
+          "item_id.{}": {
+            "label": "Предмет",
+            "hint": "Предмет, который будет размещён в качестве кнопки."
+          },
+          "slot_index.{}": {
+            "label": "Номер слота",
+            "hint": "Слот контейнера, в котором будет размещена кнопка."
+          },
+          "amount_strategy.{}": {
+            "label": "Стратегия количества",
+            "hint": "Стратегия расчёта количества.\n\nMAX: Закажет максимальное количество, доступное для данного действия (мгновенное, ордер).\nFIXED: Закажет количество, настроенное ниже."
+          },
+          "pricing_position.{}": {
+            "label": "Позиция цены",
+            "hint": "Стратегия расчёта цены ставки за предмет\n\nCOMPETITIVE: Ставка будет на +0,1 выше текущего лучшего предложения на рынке\nMATCHED: Ставка будет равна текущему лучшему предложению на рынке\nOUTBID: Ставка будет на -0,1 ниже текущего лучшего предложения на рынке"
+          },
+          "fixed_amount.{}": {
+            "label": "Фиксированное количество",
+            "hint": "Количество, которое будет использовано, если в качестве стратегии выбрано FIXED."
+          }
+        }
+      },
+
+      "bookmarks.{}": {
+        "category.label": "Закладки",
+
+        "separator.introductory.{}": {
+          "label": "Закладки предметов",
+          "hint": "Закладки предметов позволяют быстро искать нужные предметы на Bazaar."
+        },
+
+        "open_bookmark.{}": {
+          "label": "Открыть закладку",
+          "hint": "Настраивает кнопку в выбранных меню, которая быстро ищет предмет из закладок."
+        },
+
+        "toggle_bookmark.{}": {
+          "label": "Добавить в закладки",
+          "hint": "Добавляет на страницы предметов кнопку, переключающую нахождение предмета в закладках для быстрого доступа."
+        },
+
+        "reset_bookmarks.label": "Сохранённые закладки",
+        "reset_bookmarks.runnable": "Сбросить"
+      },
+
+      "helpers.{}": {
+        "category.label": "Помощники ввода",
+
+        "separator.buy_related.{}": {
+          "label": "Помощники покупки",
+          "hint": "Помощники, появляющиеся при покупке на Bazaar. Настройте кнопки для автозаполнения количества или цены при мгновенной покупке и создании ордеров на покупку."
+        },
+
+        "instant_buy_amount.label": "Количество мгновенной покупки",
+        "buy_order_amount.label": "Количество ордера на покупку",
+        "buy_order_price.label": "Цена ордера на покупку",
+
+        "separator.sell_related.{}": {
+          "label": "Помощники продажи",
+          "hint": "Помощники, появляющиеся при продаже на Bazaar. Настройте кнопки для автозаполнения количества или цены при создании предложений о продаже и флипе ордеров."
+        },
+
+        "flip_order_price.label": "Цена флипа ордера",
+        "sell_offer_amount.label": "Количество предложения о продаже",
+        "sell_offer_price.label": "Цена предложения о продаже"
+      }
+    },
+
+    "inventory.{}": {
+      "category.label": "Инвентарь",
+      "category.hint": "Настройки функций инвентаря в моде",
+
+      "separator.instant_sell_highlight.label": "Подсветка Instant Sell",
+      "instant_sell_highlight.{}": {
+        "label": "Подсветка Instant Sell",
+        "hint": [
+          "Подсвечивает в инвентаре предметы, которые будут проданы кнопкой Instant Sell."
+        ],
+        "color.label": "Цвет подсветки"
+      },
+
+      "separator.order_status_highlight.label": "Подсветка статуса ордеров",
+      "order_status_highlight.{}": {
+        "label": "Подсветка статуса ордеров",
+        "hint": "Показывает статус ваших ордеров на Bazaar, окрашивая предметы соответствующими цветами.",
+
+        "competitive_color.{}": {
+          "label": "Цвет лучшего предложения",
+          "hint": "Цвет подсветки для ордеров, которые сейчас являются лучшим предложением на рынке."
+        },
+
+        "matched_color.{}": {
+          "label": "Цвет совпадения с рынком",
+          "hint": "Цвет подсветки для ордеров, совпадающих с текущей рыночной ценой."
+        },
+
+        "outbid_color.{}": {
+          "label": "Цвет перебитой ставки",
+          "hint": "Цвет подсветки для ордеров, ставку по которым перебили."
+        }
+      },
+
+      "restrictions.{}": {
+        "separator.introductory.{}": {
+          "label": "Ограничения инвентаря"
+        },
+
+        "category.label": "Ограничения инвентаря",
+
+        "enabled.{}": {
+          "label": "Ограничения инвентаря",
+          "hint": "Блокирует выбранные кнопки Bazaar на основе условий инвентаря или действия, чтобы предотвратить случайные операции на рынке."
+        },
+
+        "features.{}": {
+          "label": "Ограниченные кнопки",
+          "hint": "Кнопки инвентаря, для которых включены ограничения.",
+
+          "target.{}": {
+            "instant_sell.label": "Instant Sell",
+            "sell_sacks.label": "Sell Sacks"
+          }
+        },
+
+        "clicks_required.{}": {
+          "label": "Требуется нажатий",
+          "hint": "Количество нажатий на кнопку функции, необходимое для подтверждения действия."
+        },
+
+        "separator.rules_informational.{}": {
+          "label": "Правила ограничений",
+          "hint": "Управление правилами, которые проверяет функция ограничений"
+        },
+
+        "numeric_restrictions.{}": {
+          "label": "Числовые условия",
+          "hint": "Правила, проверяющие числовые условия (например, общее количество предметов или монет), чтобы ограничить выбранные действия."
+        },
+
+        "string_restrictions.{}": {
+          "label": "Условия по названию",
+          "hint": "Правила, проверяющие конкретные названия или типы предметов, чтобы ограничить выбранные действия."
+        },
+
+        "control.{}": {
+          "targets.{}": {
+            "label": "Функции",
+            "hint": "Функции, для которых действует это правило."
+          },
+
+          "numeric.{}": {
+            "type.{}": {
+              "label": "Тип ограничения",
+              "hint": "Срабатывает ли ограничение по общей стоимости в монетах или по количеству предметов."
+            },
+            "threshold.{}": {
+              "label": "Порог",
+              "hint": "Значение, при превышении которого сработает ограничение."
+            }
+          },
+
+          "name.{}": {
+            "value.{}": {
+              "label": "Название предмета",
+              "hint": "Название предмета, которое вызовет ограничение, если оно присутствует в действии продажи."
+            }
+          }
+        }
+      }
+    },
+
+    "overlays.{}": {
+      "category.label": "Оверлеи",
+      "category.hint": "Настройки оверлеев, создаваемых модом",
+
+      "separator.price_charts.label": "Графики цен",
+      "price_charts.{}": {
+        "label": "Графики цен",
+        "hint": "Добавляет во всплывающие подсказки предметов Bazaar ссылку для быстрого перехода к графикам рыночных цен.",
+        "show_outside_bazaar.{}": {
+          "label": "Показывать вне Bazaar",
+          "hint": "Показывать ли графики цен в подсказках вне меню Bazaar."
+        }
+      },
+
+      "separator.bazaar_limits_visualizer.label": "Лимиты Bazaar",
+      "bazaar_limits_visualizer.{}": {
+        "label": "Лимиты Bazaar",
+        "hint": [
+          "Отображает состояние вашего дневного лимита Bazaar на экранах Bazaar.\n\nПрофили ограничены суммой ",
+          {
+            "text": "15 000 000 000,00 монет",
+            "color": "gold",
+            "hover_event": {
+              "action": "show_text",
+              "value": [
+                { "text": "Дневной лимит Bazaar\n", "color": "gold", "bold": true },
+                { "text": "Сбрасывается в полночь по UTC.\n", "color": "gray" },
+                { "text": "Действует на профиль, а не на аккаунт.", "color": "dark_gray", "italic": true }
+              ]
+            }
+          },
+          " в торгуемых ордерах/предложениях в день."
+        ],
+        "reset_limits.label": "Дневные лимиты ордеров",
+        "reset_limits.runnable": "Сбросить"
+      }
+    },
+
+    "notifications.{}": {
+      "category.label": "Уведомления",
+      "category.hint": "Настройки уведомлений, отправляемых модом",
+
+      "separator.order_notifications.label": "Уведомления об ордерах",
+      "order_notifications.{}": {
+        "label": "Уведомления об ордерах",
+        "hint": "Включает уведомления, связанные со статусом ваших ордеров на Bazaar.",
+        "outbid.{}": {
+          "label": "Ставку по ордеру перебили",
+          "hint": "Настраивает уведомление, показываемое, когда ставку по вашему ордеру перебили."
+        },
+        "filled.{}": {
+          "label": "Ордер выполнен",
+          "hint": "Настраивает уведомление, показываемое, когда ваш ордер выполнен."
+        }
+      },
+
+      "notification.{}": {
+        "enabled.{}": {
+          "label": "Включено",
+          "hint": "Будет ли создаваться уведомление."
+        },
+        "auto_open_bazaar.label": "Автоматически открывать Bazaar",
+        "emit_chat_message.label": "Отправлять сообщение в чат",
+        "emit_client_sound.label": "Воспроизводить звук на клиенте"
+      }
+    },
+
+    "advanced.{}": {
+      "category.label": "Расширенные настройки",
+      "category.hint": "Расширенные настройки процессов и функций мода",
+      "auto_update.{}": {
+        "label": "Автообновление",
+        "hint": "Автоматически обновлять мод при обнаружении обновления."
+      }
+    },
+
+    "developer.{}": {
+      "category.label": "Настройки разработчика",
+      "category.hint": "Настройки разработчика и переключаемые инструменты мода",
+      "enabled.{}": {
+        "label": "Включено",
+        "hint": "Общий переключатель для всех функций и утилит разработчика."
+      },
+      "disable_error_notifications.label": "Отключить уведомления об ошибках",
+      "debug_messages.{}": {
+        "label": "Отладочные сообщения",
+        "hint": "Настраивает отладочные сообщения в чате о процессах и состоянии мода"
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/bazaarutils/lang/zh_cn.json5
+++ b/src/main/resources/assets/bazaarutils/lang/zh_cn.json5
@@ -1,0 +1,429 @@
+{
+  "owo:extended_lang": true,
+
+  "bazaarutils.ref.{}": {
+    "instant_sell": [{
+      "text": "Instant Sell",
+      "color": "green"
+    }],
+
+    "booster_cookie": [{
+      "text": "Booster Cookie",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Booster Cookie\n", "color": "light_purple", "bold": true },
+          { "text": "可使用 Bazaar 订单 API，\n并获得其他 SkyBlock 特权。\n\n", "color": "gray" },
+          { "text": "↗ 点击打开 Wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Booster_Cookie"
+      }
+    }],
+
+    "bazaar_flipper": [{
+      "text": "Bazaar Flipper",
+      "color": "gold",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Bazaar Flipper\n", "color": "gold", "bold": true },
+          { "text": "一项账号升级，可降低交易税\n并提高你的活跃订单上限。\n\n", "color": "gray" },
+          { "text": "↗ 点击打开 Wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Bazaar_Flipper"
+      }
+    }],
+
+    "elizabeth": [{
+      "text": "Elizabeth",
+      "color": "light_purple",
+      "hover_event": {
+        "action": "show_text",
+        "value": [
+          { "text": "Elizabeth\n", "color": "light_purple", "bold": true },
+          { "text": "位于 SkyBlock Hub ", "color": "gray" },
+          { "text": "Community Center", "color": "gray" },
+          { "text": " 的 NPC。\n", "color": "gray" },
+          { "text": "使用 Gems 出售账号升级。\n\n", "color": "gray" },
+          { "text": "↗ 点击打开 Wiki", "color": "dark_gray", "italic": true }
+        ]
+      },
+      "click_event": {
+        "action": "open_url",
+        "url": "https://wiki.hypixel.net/Elizabeth"
+      }
+    }],
+
+    "community_center": [{ "text": "Community Center", "color": "aqua" }],
+    "skyblock_hub": [{ "text": "SkyBlock Hub", "color": "aqua" }]
+  },
+
+  "mod.bazaarutils": "Bazaar Utils",
+  "key.category.minecraft.bazaarutils": "Bazaar Utils",
+
+  "bazaarutils.rconfig.ui.{}": {
+    "constant.{}": {
+      "search": "搜索...",
+      "select": "选择"
+    }
+  },
+
+  "bazaarutils.hypixel.account_upgrades.bazaar_flipper.{}": {
+    "not_upgraded.label": "未升级",
+    "first_tier.label": "Bazaar Flipper I",
+    "second_tier.label": "Bazaar Flipper II"
+  },
+
+  "bazaarutils.config.{}": {
+
+    "separator.introductory.label": "欢迎使用 Bazaar Utils！",
+    "separator.introductory.hint": "感谢你安装 Bazaar Utils！本模组为 Hypixel Bazaar 提供了多项便利功能。",
+
+    "bazaar_flipper_account_upgrade.{}": {
+      "label": "Bazaar Flipper 账号升级",
+      "hint": [
+        "你的 ", { "translate": "bazaarutils.ref.bazaar_flipper" },
+        " 账号升级等级，会影响交易税的计算与当前的订单上限。",
+        "\n你可以前往 ",
+        { "translate": "bazaarutils.ref.skyblock_hub" }, " 的 ",
+        { "translate": "bazaarutils.ref.community_center" }, "，与 ",
+        { "translate": "bazaarutils.ref.elizabeth" }, " 对话来提升 Bazaar Flipper 等级。"
+      ]
+    },
+
+    "chat.{}": {
+      "category.label": "聊天",
+      "category.hint": "模组聊天功能的相关设置",
+
+      "separator.useless_bazaar_notifications_remover.label": "无用的 Bazaar 提示",
+      "useless_bazaar_notifications_remover.{}": {
+        "label": "无用的 Bazaar 提示",
+        "hint": "移除与 Bazaar 交互时发送到聊天栏的部分临时消息，减少刷屏。",
+        "excluded_notifications.{}": {
+          "label": "排除的提示",
+          "hint": "需要在聊天栏中屏蔽的消息与提示列表。"
+        }
+      },
+
+      "separator.stash_messages_remover.label": "Stash 提示消息",
+      "stash_messages_remover.{}": {
+        "label": "Stash 提示消息",
+        "hint": "移除提醒你从 Stash 中领取物品的聊天消息。"
+      }
+    },
+
+    "buttons.{}": {
+      "category.label": "按钮",
+      "category.hint": "模组添加与管理的按钮的相关设置",
+
+      "separator.mod_buttons.{}": {
+        "label": "模组按钮",
+        "hint": "在物品栏界面添加按钮，以便快速使用模组功能。"
+      },
+
+      "open_settings.{}": {
+        "label": "模组设置按钮",
+        "hint": "在指定菜单中添加一个按钮，用于快速打开模组设置。"
+      },
+
+      "open_orders.{}": {
+        "label": "订单页面按钮",
+        "hint": [
+          "在指定菜单中添加一个按钮，用于快速打开你的订单页面。",
+          "\n\n需要生效中的 ", { "translate": "bazaarutils.ref.booster_cookie" }, "。"
+        ]
+      },
+
+      "separator.container_buttons.{}": {
+        "label": "容器按钮",
+        "hint": "在特定的容器界面中添加辅助按钮。"
+      },
+
+      "cancel_order_and_search.{}": {
+        "label": "取消并搜索按钮",
+        "hint": "在未完成的订单/报价页面添加一个按钮，用于取消订单并立即重新搜索该物品。"
+      },
+
+      "button.{}": {
+        "widget.{}": {
+          "enabled.{}": {
+            "label": "启用",
+            "hint": "是否启用该按钮。"
+          },
+          "size.label": "按钮大小",
+          "spacing.label": "间距"
+        },
+        "container.{}": {
+          "enabled.{}": {
+            "label": "启用",
+            "hint": "是否启用该按钮。"
+          },
+          "item_id.{}": {
+            "label": "物品",
+            "hint": "将作为按钮放置的物品。"
+          },
+          "slot_index.{}": {
+            "label": "槽位编号",
+            "hint": "按钮将被放置的容器槽位。"
+          },
+          "amount_strategy.{}": {
+            "label": "数量策略",
+            "hint": "计算数量的策略。\n\nMAX：按当前操作（即时交易、挂单）所允许的最大数量下单。\nFIXED：按下方配置的数量下单。"
+          },
+          "pricing_position.{}": {
+            "label": "定价策略",
+            "hint": "计算每件物品出价的策略\n\nCOMPETITIVE：出价比当前市场最优报价高 0.1\nMATCHED：出价与当前市场最优报价相同\nOUTBID：出价比当前市场最优报价低 0.1"
+          },
+          "fixed_amount.{}": {
+            "label": "固定数量",
+            "hint": "当数量策略设置为 FIXED 时所使用的数量。"
+          }
+        }
+      },
+
+      "bookmarks.{}": {
+        "category.label": "书签",
+
+        "separator.introductory.{}": {
+          "label": "物品书签",
+          "hint": "物品书签可以让你在 Bazaar 中快速搜索指定物品。"
+        },
+
+        "open_bookmark.{}": {
+          "label": "打开书签",
+          "hint": "配置指定菜单中用于快速搜索书签物品的按钮。"
+        },
+
+        "toggle_bookmark.{}": {
+          "label": "收藏物品",
+          "hint": "在物品页面添加一个按钮，用于切换该物品是否被加入书签以便快速访问。"
+        },
+
+        "reset_bookmarks.label": "已保存的书签",
+        "reset_bookmarks.runnable": "重置"
+      },
+
+      "helpers.{}": {
+        "category.label": "输入助手",
+
+        "separator.buy_related.{}": {
+          "label": "购买助手",
+          "hint": "在 Bazaar 购买时出现的助手。可配置按钮，在即时购买或挂收购单时自动填写数量或价格。"
+        },
+
+        "instant_buy_amount.label": "即时购买数量",
+        "buy_order_amount.label": "收购订单数量",
+        "buy_order_price.label": "收购订单价格",
+
+        "separator.sell_related.{}": {
+          "label": "出售助手",
+          "hint": "在 Bazaar 出售时出现的助手。可配置按钮，在挂出售单或翻转订单时自动填写数量或价格。"
+        },
+
+        "flip_order_price.label": "翻转订单价格",
+        "sell_offer_amount.label": "出售订单数量",
+        "sell_offer_price.label": "出售订单价格"
+      }
+    },
+
+    "inventory.{}": {
+      "category.label": "物品栏",
+      "category.hint": "模组物品栏功能的相关设置",
+
+      "separator.instant_sell_highlight.label": "Instant Sell 高亮",
+      "instant_sell_highlight.{}": {
+        "label": "Instant Sell 高亮",
+        "hint": [
+          "高亮显示物品栏中会被 Instant Sell 按钮卖出的物品。"
+        ],
+        "color.label": "高亮颜色"
+      },
+
+      "separator.order_status_highlight.label": "订单状态高亮",
+      "order_status_highlight.{}": {
+        "label": "订单状态高亮",
+        "hint": "通过为物品染上对应颜色来显示你的 Bazaar 订单状态。",
+
+        "competitive_color.{}": {
+          "label": "最优报价颜色",
+          "hint": "当前为市场最优报价的订单所使用的高亮颜色。"
+        },
+
+        "matched_color.{}": {
+          "label": "持平报价颜色",
+          "hint": "与当前市场价格持平的订单所使用的高亮颜色。"
+        },
+
+        "outbid_color.{}": {
+          "label": "被超越报价颜色",
+          "hint": "已被他人超越报价的订单所使用的高亮颜色。"
+        }
+      },
+
+      "restrictions.{}": {
+        "separator.introductory.{}": {
+          "label": "物品栏限制"
+        },
+
+        "category.label": "物品栏限制",
+
+        "enabled.{}": {
+          "label": "物品栏限制",
+          "hint": "根据物品栏或操作条件锁定指定的 Bazaar 按钮，防止误操作交易。"
+        },
+
+        "features.{}": {
+          "label": "受限按钮",
+          "hint": "启用了限制的物品栏按钮。",
+
+          "target.{}": {
+            "instant_sell.label": "Instant Sell",
+            "sell_sacks.label": "Sell Sacks"
+          }
+        },
+
+        "clicks_required.{}": {
+          "label": "所需点击次数",
+          "hint": "确认该操作所需在功能按钮上点击的次数。"
+        },
+
+        "separator.rules_informational.{}": {
+          "label": "限制规则",
+          "hint": "管理限制功能所检查的规则"
+        },
+
+        "numeric_restrictions.{}": {
+          "label": "数值条件",
+          "hint": "检查数值条件（例如物品总数或金币总额）以限制目标操作的规则。"
+        },
+
+        "string_restrictions.{}": {
+          "label": "名称条件",
+          "hint": "检查特定物品名称或类型以限制目标操作的规则。"
+        },
+
+        "control.{}": {
+          "targets.{}": {
+            "label": "功能",
+            "hint": "该规则生效的功能。"
+          },
+
+          "numeric.{}": {
+            "type.{}": {
+              "label": "限制类型",
+              "hint": "限制是基于金币总价值触发，还是基于物品数量触发。"
+            },
+            "threshold.{}": {
+              "label": "阈值",
+              "hint": "超过该数值时将触发限制。"
+            }
+          },
+
+          "name.{}": {
+            "value.{}": {
+              "label": "物品名称",
+              "hint": "若出售操作中包含该物品名称，则会触发限制。"
+            }
+          }
+        }
+      }
+    },
+
+    "overlays.{}": {
+      "category.label": "覆盖层",
+      "category.hint": "模组创建的覆盖层的相关设置",
+
+      "separator.price_charts.label": "价格图表",
+      "price_charts.{}": {
+        "label": "价格图表",
+        "hint": "在 Bazaar 物品提示框中添加链接，便于快速查看市场价格图表。",
+        "show_outside_bazaar.{}": {
+          "label": "在 Bazaar 之外显示",
+          "hint": "在 Bazaar 菜单之外时，是否仍在提示框中显示价格图表。"
+        }
+      },
+
+      "separator.bazaar_limits_visualizer.label": "Bazaar 限额",
+      "bazaar_limits_visualizer.{}": {
+        "label": "Bazaar 限额",
+        "hint": [
+          "在 Bazaar 界面显示你的每日 Bazaar 限额状态。\n\n每个档案每天的可交易订单/报价上限为 ",
+          {
+            "text": "15,000,000,000.00 金币",
+            "color": "gold",
+            "hover_event": {
+              "action": "show_text",
+              "value": [
+                { "text": "每日 Bazaar 限额\n", "color": "gold", "bold": true },
+                { "text": "于 UTC 午夜重置。\n", "color": "gray" },
+                { "text": "按档案计算，而非按账号计算。", "color": "dark_gray", "italic": true }
+              ]
+            }
+          },
+          "。"
+        ],
+        "reset_limits.label": "每日订单限额",
+        "reset_limits.runnable": "重置"
+      }
+    },
+
+    "notifications.{}": {
+      "category.label": "通知",
+      "category.hint": "模组推送的通知的相关设置",
+
+      "separator.order_notifications.label": "订单通知",
+      "order_notifications.{}": {
+        "label": "订单通知",
+        "hint": "启用与你的 Bazaar 订单状态相关的通知。",
+        "outbid.{}": {
+          "label": "订单被超越报价",
+          "hint": "配置当你的订单被他人超越报价时显示的通知。"
+        },
+        "filled.{}": {
+          "label": "订单已完成",
+          "hint": "配置当你的订单完成时显示的通知。"
+        }
+      },
+
+      "notification.{}": {
+        "enabled.{}": {
+          "label": "启用",
+          "hint": "是否发出该通知。"
+        },
+        "auto_open_bazaar.label": "自动打开 Bazaar",
+        "emit_chat_message.label": "发送聊天消息",
+        "emit_client_sound.label": "播放客户端音效"
+      }
+    },
+
+    "advanced.{}": {
+      "category.label": "高级设置",
+      "category.hint": "模组流程与功能的高级设置",
+      "auto_update.{}": {
+        "label": "自动更新",
+        "hint": "在发现新版本时自动更新模组。"
+      }
+    },
+
+    "developer.{}": {
+      "category.label": "开发者设置",
+      "category.hint": "模组的开发者设置与可切换工具",
+      "enabled.{}": {
+        "label": "启用",
+        "hint": "所有开发者功能与工具的总开关。"
+      },
+      "disable_error_notifications.label": "禁用错误通知",
+      "debug_messages.{}": {
+        "label": "调试消息",
+        "hint": "配置发送到聊天栏的、关于模组流程与状态的调试消息"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses the translation half of #63 by adding the five languages listed there.

## What's added

New owo extended-lang files under `src/main/resources/assets/bazaarutils/lang/`:

| Locale | File |
| --- | --- |
| German | `de_de.json5` |
| Polish | `pl_pl.json5` |
| French | `fr_fr.json5` |
| Chinese (Simplified) | `zh_cn.json5` |
| Russian | `ru_ru.json5` |

Each mirrors the full key structure of `en_us.json5` — 222 keys, verified identical (no missing or extra keys), including the nested `{}` groups, the `bazaarutils.ref.*` components with their hover/click events, and the multi-part `hint` arrays that embed `{"translate": ...}` references.

## Translation choices

- **Hypixel proper nouns stay in English** — `Booster Cookie`, `Bazaar Flipper`, `Elizabeth`, `Community Center`, `SkyBlock Hub`, `Instant Sell`, `Sell Sacks`. SkyBlock's own UI is English-only, so leaving these untranslated keeps them matchable against what players actually see in game. Their surrounding descriptions, hover tooltips and labels are localised.
- **Enum values stay in English** — `MAX` / `FIXED` in the amount-strategy hint and `COMPETITIVE` / `MATCHED` / `OUTBID` in the pricing-position hint, since those strings are the values shown in the config dropdowns.
- **Wiki URLs and all colour/formatting fields are unchanged** from `en_us.json5`.
- **Number formatting follows each locale** in the daily Bazaar limit hint (`15.000.000.000,00` for de, `15 000 000 000,00` for pl/fr/ru, `15,000,000,000.00` for zh).
- In `zh_cn` the ref components in the Bazaar Flipper hint are reordered (location before NPC) to fit Chinese word order; all four references are still present.

## Verification

Parsed all five files and diffed their key sets and component structure (translate refs, colours, actions, URLs) against `en_us.json5` — clean, with the one intentional zh word-order reordering noted above.

## Not included

The second part of #63 — "turn string user messages into translations" — is not in this PR. That's a code change across the mod's chat/notification messages rather than a resource addition, and is better kept as its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di7Jq78uQSWrE39RD8sRfP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Di7Jq78uQSWrE39RD8sRfP)_